### PR TITLE
remove double pipes

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -27,7 +27,7 @@ const program = Effect.gen(function*($) {
     Stream.map(Option.some),
     Stream.concat(Stream.make(Option.none))
   )
-  const { result1, result2 } = yield* $(pipe(
+  const { result1, result2 } = yield* $(
     Effect.all({
       result1: pipe(
         stream,
@@ -41,7 +41,7 @@ const program = Effect.gen(function*($) {
         Stream.runCollect
       )
     })
-  ))
+  )
   const equal = Equal.equals(result2)(result1)
   return { equal, result1: Array.from(result1), result2: Array.from(result2) }
 })

--- a/examples/size.ts
+++ b/examples/size.ts
@@ -10,7 +10,7 @@ const program = Effect.gen(function*($) {
     Chunk.flatten,
     Chunk.map((n) => String(n))
   )
-  const result = yield* $(pipe(
+  const result = yield* $(
     Stream.fromIterable(words),
     Stream.groupByKey(identity, { bufferSize: 8192 }),
     GroupBy.evaluate((key, stream) =>
@@ -21,7 +21,7 @@ const program = Effect.gen(function*($) {
       )
     ),
     Stream.runCollect
-  ))
+  )
   console.log(
     Array.from(result),
     Array.from({ length: 100 }, (_, i) => i).map((n) => [String(n), 100] as const)

--- a/examples/subscription.ts
+++ b/examples/subscription.ts
@@ -20,11 +20,11 @@ const program = Effect.gen(function*($) {
       Effect.tap(() => Effect.log("STOPPED"))
     )
   const subscriptionRef = yield* $(SubscriptionRef.make(0))
-  const fiber = yield* $(pipe(
+  const fiber = yield* $(
     SubscriptionRef.update(subscriptionRef, (n) => n + 1),
     Effect.forever,
     Effect.fork
-  ))
+  )
   const result = yield* $(Effect.all(
     Array.from({ length: 2 }, () => subscriber(subscriptionRef)),
     { concurrency: 2 }

--- a/src/internal/groupBy.ts
+++ b/src/internal/groupBy.ts
@@ -162,13 +162,11 @@ export const groupBy = dual<
           ))
           const ref = yield* $(Ref.make<Map<K, number>>(new Map()))
           const add = yield* $(
-            pipe(
-              stream.mapEffectSequential(self, f),
-              stream.distributedWithDynamicCallback(
-                options?.bufferSize ?? 16,
-                ([key, value]) => Effect.flatMap(Deferred.await(decider), (f) => f(key, value)),
-                (exit) => Queue.offer(output, exit)
-              )
+            stream.mapEffectSequential(self, f),
+            stream.distributedWithDynamicCallback(
+              options?.bufferSize ?? 16,
+              ([key, value]) => Effect.flatMap(Deferred.await(decider), (f) => f(key, value)),
+              (exit) => Queue.offer(output, exit)
             )
           )
           yield* $(

--- a/src/internal/stream.ts
+++ b/src/internal/stream.ts
@@ -1366,22 +1366,18 @@ export const combine = dual<
         const latchL = yield* $(Handoff.make<void>())
         const latchR = yield* $(Handoff.make<void>())
         yield* $(
-          pipe(
-            toChannel(self),
-            channel.concatMap(channel.writeChunk),
-            core.pipeTo(producer(left, latchL)),
-            channelExecutor.runScoped,
-            Effect.forkScoped
-          )
+          toChannel(self),
+          channel.concatMap(channel.writeChunk),
+          core.pipeTo(producer(left, latchL)),
+          channelExecutor.runScoped,
+          Effect.forkScoped
         )
         yield* $(
-          pipe(
-            toChannel(that),
-            channel.concatMap(channel.writeChunk),
-            core.pipeTo(producer(right, latchR)),
-            channelExecutor.runScoped,
-            Effect.forkScoped
-          )
+          toChannel(that),
+          channel.concatMap(channel.writeChunk),
+          core.pipeTo(producer(right, latchR)),
+          channelExecutor.runScoped,
+          Effect.forkScoped
         )
         const pullLeft = pipe(
           latchL,
@@ -2047,7 +2043,7 @@ export const distributedWithDynamicCallback = dual<
               Effect.asUnit
             )
           )
-        yield* $(pipe(
+        yield* $(
           self,
           runForEachScoped(offer),
           Effect.matchCauseEffect({
@@ -2055,7 +2051,7 @@ export const distributedWithDynamicCallback = dual<
             onSuccess: () => finalize(Exit.fail(Option.none()))
           }),
           Effect.forkScoped
-        ))
+        )
         return queuesLock.withPermits(1)(
           Effect.flatten(Ref.get(newQueue))
         )

--- a/test/Channel/environment.ts
+++ b/test/Channel/environment.ts
@@ -45,11 +45,9 @@ describe.concurrent("Channel", () => {
   it.effect("provide - simple", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          NumberService,
-          Channel.provideService(NumberService, new NumberServiceImpl(100)),
-          Channel.run
-        )
+        NumberService,
+        Channel.provideService(NumberService, new NumberServiceImpl(100)),
+        Channel.run
       )
       assert.deepStrictEqual(result, new NumberServiceImpl(100))
     }))
@@ -57,24 +55,22 @@ describe.concurrent("Channel", () => {
   it.effect("provide -> zip -> provide", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          NumberService,
-          Channel.provideService(NumberService, new NumberServiceImpl(100)),
-          Channel.zip(
-            pipe(
-              NumberService,
-              Channel.provideService(NumberService, new NumberServiceImpl(200))
-            )
-          ),
-          Channel.run
-        )
+        NumberService,
+        Channel.provideService(NumberService, new NumberServiceImpl(100)),
+        Channel.zip(
+          pipe(
+            NumberService,
+            Channel.provideService(NumberService, new NumberServiceImpl(200))
+          )
+        ),
+        Channel.run
       )
       assert.deepStrictEqual(result, [new NumberServiceImpl(100), new NumberServiceImpl(200)])
     }))
 
   it.effect("concatMap(provide).provide", () =>
     Effect.gen(function*($) {
-      const [chunk, value] = yield* $(pipe(
+      const [chunk, value] = yield* $(
         Channel.fromEffect(NumberService),
         Channel.emitCollect,
         Channel.mapOut((tuple) => tuple[1]),
@@ -88,7 +84,7 @@ describe.concurrent("Channel", () => {
         ),
         Channel.provideService(NumberService, new NumberServiceImpl(100)),
         Channel.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(chunk), [[new NumberServiceImpl(100), new NumberServiceImpl(200)] as const])
       assert.isUndefined(value)
     }))
@@ -102,13 +98,13 @@ describe.concurrent("Channel", () => {
         Channel.fromEffect
       )
       const channel3 = Channel.fromEffect(NumberService)
-      const [[result1, result2], result3] = yield* $(pipe(
+      const [[result1, result2], result3] = yield* $(
         channel1,
         Channel.zip(channel2),
         Channel.zip(channel3),
         Channel.runDrain,
         Effect.provideService(NumberService, new NumberServiceImpl(4))
-      ))
+      )
       assert.deepStrictEqual(result1, new NumberServiceImpl(4))
       assert.deepStrictEqual(result2, new NumberServiceImpl(2))
       assert.deepStrictEqual(result3, new NumberServiceImpl(4))

--- a/test/Channel/error-handling.ts
+++ b/test/Channel/error-handling.ts
@@ -34,14 +34,12 @@ describe.concurrent("Channel", () => {
         Effect.zipRight(Effect.never)
       )
       yield* $(
-        pipe(
-          Channel.fromEffect(effect),
-          Channel.runDrain,
-          Effect.onExit((exit) => Ref.set(ref, exit as Exit.Exit<never, void>)),
-          Effect.ensuring(Deferred.succeed(finished, void 0)),
-          Effect.race(Deferred.await(deferred)),
-          Effect.either
-        )
+        Channel.fromEffect(effect),
+        Channel.runDrain,
+        Effect.onExit((exit) => Ref.set(ref, exit as Exit.Exit<never, void>)),
+        Effect.ensuring(Deferred.succeed(finished, void 0)),
+        Effect.race(Deferred.await(deferred)),
+        Effect.either
       )
       yield* $(Deferred.await(finished)) // Note: interruption in race is now done in the background
       const result = yield* $(Ref.get(ref))
@@ -51,7 +49,7 @@ describe.concurrent("Channel", () => {
   it.effect("scoped failures", () =>
     Effect.gen(function*($) {
       const channel = Channel.scoped(Effect.fail("error"))
-      const result = yield* $(pipe(Channel.runCollect(channel), Effect.exit))
+      const result = yield* $(Channel.runCollect(channel), Effect.exit)
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("error"))
     }))
 })

--- a/test/Channel/finalization.ts
+++ b/test/Channel/finalization.ts
@@ -36,7 +36,7 @@ describe.concurrent("Channel", () => {
           )
         )
       )
-      const result = yield* $(pipe(Channel.runDrain(channel), Effect.zipRight(Ref.get(ref))))
+      const result = yield* $(Channel.runDrain(channel), Effect.zipRight(Ref.get(ref)))
       assert.deepStrictEqual(result, [
         "Acquire1",
         "Release11",
@@ -64,12 +64,12 @@ describe.concurrent("Channel", () => {
         ),
         Channel.ensuring(event("ReleaseOuter"))
       )
-      const [eventsInScope, eventsOutsideScope] = yield* $(pipe(
+      const [eventsInScope, eventsOutsideScope] = yield* $(
         Channel.toPull(channel),
         Effect.flatMap((pull) => pipe(Effect.exit(pull), Effect.zipRight(Ref.get(ref)))),
         Effect.scoped,
         Effect.zip(Ref.get(ref))
-      ))
+      )
       assert.deepStrictEqual(eventsInScope, [
         "Acquire1",
         "Release11",
@@ -109,10 +109,8 @@ describe.concurrent("Channel", () => {
         Channel.ensuring(event("Second concatMap"))
       )
       const [[elements], events] = yield* $(
-        pipe(
-          Channel.runCollect(channel),
-          Effect.zip(Ref.get(ref))
-        )
+        Channel.runCollect(channel),
+        Effect.zip(Ref.get(ref))
       )
       assert.deepStrictEqual(events, [
         "Second write",

--- a/test/Channel/interruption.ts
+++ b/test/Channel/interruption.ts
@@ -24,10 +24,8 @@ describe.concurrent("Channel", () => {
       )
       const fiber = yield* $(Effect.fork(Channel.runDrain(channel)))
       yield* $(
-        pipe(
-          Deferred.await(started),
-          Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
-        )
+        Deferred.await(started),
+        Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
       )
       yield* $(Fiber.await(fiber))
       const result = yield* $(Ref.get(interrupted))
@@ -61,10 +59,8 @@ describe.concurrent("Channel", () => {
       )
       const fiber = yield* $(Effect.fork(Channel.runDrain(channel)))
       yield* $(
-        pipe(
-          Deferred.await(started),
-          Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
-        )
+        Deferred.await(started),
+        Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
       )
       yield* $(Fiber.await(fiber))
       const result = yield* $(Ref.get(interrupted))

--- a/test/Channel/mapping.ts
+++ b/test/Channel/mapping.ts
@@ -30,11 +30,9 @@ describe.concurrent("Channel", () => {
   it.effect("map", () =>
     Effect.gen(function*($) {
       const [chunk, value] = yield* $(
-        pipe(
-          Channel.succeed(1),
-          Channel.map((n) => n + 1),
-          Channel.runCollect
-        )
+        Channel.succeed(1),
+        Channel.map((n) => n + 1),
+        Channel.runCollect
       )
       assert.isTrue(Chunk.isEmpty(chunk))
       assert.strictEqual(value, 2)
@@ -43,12 +41,10 @@ describe.concurrent("Channel", () => {
   it.effect("mapError - structure confusion", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.fail("error"),
-          Channel.mapError(() => 1),
-          Channel.runCollect,
-          Effect.exit
-        )
+        Channel.fail("error"),
+        Channel.mapError(() => 1),
+        Channel.runCollect,
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(1))
     }))
@@ -56,11 +52,9 @@ describe.concurrent("Channel", () => {
   it.effect("mapOut - simple", () =>
     Effect.gen(function*($) {
       const [chunk, value] = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3),
-          Channel.mapOut((n) => n + 1),
-          Channel.runCollect
-        )
+        Channel.writeAll(1, 2, 3),
+        Channel.mapOut((n) => n + 1),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), [2, 3, 4])
       assert.isUndefined(value)
@@ -69,12 +63,10 @@ describe.concurrent("Channel", () => {
   it.effect("mapOut - mixed with flatMap", () =>
     Effect.gen(function*($) {
       const [chunk, value] = yield* $(
-        pipe(
-          Channel.write(1),
-          Channel.mapOut((n) => `${n}`),
-          Channel.flatMap(() => Channel.write("x")),
-          Channel.runCollect
-        )
+        Channel.write(1),
+        Channel.mapOut((n) => `${n}`),
+        Channel.flatMap(() => Channel.write("x")),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), ["1", "x"])
       assert.isUndefined(value)
@@ -83,11 +75,9 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - plain", () =>
     Effect.gen(function*($) {
       const [result] = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3),
-          Channel.concatMap((i) => Channel.writeAll(i, i)),
-          Channel.runCollect
-        )
+        Channel.writeAll(1, 2, 3),
+        Channel.concatMap((i) => Channel.writeAll(i, i)),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [1, 1, 2, 2, 3, 3])
     }))
@@ -95,14 +85,12 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - complex", () =>
     Effect.gen(function*($) {
       const [result] = yield* $(
-        pipe(
-          Channel.writeAll(1, 2),
-          Channel.concatMap((i) => Channel.writeAll(i, i)),
-          Channel.mapOut(First),
-          Channel.concatMap((i) => Channel.writeAll(i, i)),
-          Channel.mapOut(Second),
-          Channel.runCollect
-        )
+        Channel.writeAll(1, 2),
+        Channel.concatMap((i) => Channel.writeAll(i, i)),
+        Channel.mapOut(First),
+        Channel.concatMap((i) => Channel.writeAll(i, i)),
+        Channel.mapOut(Second),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [
         Second(First(1)),
@@ -128,11 +116,9 @@ describe.concurrent("Channel", () => {
         Channel.concatMap(() => pipe(reader, Channel.flatMap(() => reader)))
       )
       const [result] = yield* $(
-        pipe(
-          source,
-          Channel.pipeTo(readers),
-          Channel.runCollect
-        )
+        source,
+        Channel.pipeTo(readers),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4])
     }))
@@ -140,12 +126,10 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - downstream failure", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.write(0),
-          Channel.concatMap(() => Channel.fail("error")),
-          Channel.runCollect,
-          Effect.exit
-        )
+        Channel.write(0),
+        Channel.concatMap(() => Channel.fail("error")),
+        Channel.runCollect,
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("error"))
     }))
@@ -160,7 +144,7 @@ describe.concurrent("Channel", () => {
         Channel.runDrain,
         Effect.exit
       )
-      const [exit, events] = yield* $(pipe(effect, Effect.zip(Ref.get(ref))))
+      const [exit, events] = yield* $(effect, Effect.zip(Ref.get(ref)))
       assert.deepStrictEqual(Exit.unannotate(exit), Exit.fail("error"))
       assert.deepStrictEqual(events, ["Acquired", "Released"])
     }))
@@ -168,13 +152,11 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - multiple concatMaps with failure in first", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.write(void 0),
-          Channel.concatMap(() => Channel.write(Channel.fail("error"))),
-          Channel.concatMap((e) => e),
-          Channel.runCollect,
-          Effect.exit
-        )
+        Channel.write(void 0),
+        Channel.concatMap(() => Channel.write(Channel.fail("error"))),
+        Channel.concatMap((e) => e),
+        Channel.runCollect,
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("error"))
     }))
@@ -182,13 +164,11 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - with failure then flatMap", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.write(void 0),
-          Channel.concatMap(() => Channel.fail("error")),
-          Channel.flatMap(() => Channel.write(void 0)),
-          Channel.runCollect,
-          Effect.exit
-        )
+        Channel.write(void 0),
+        Channel.concatMap(() => Channel.fail("error")),
+        Channel.flatMap(() => Channel.write(void 0)),
+        Channel.runCollect,
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("error"))
     }))
@@ -196,13 +176,11 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - multiple concatMaps with failure in first and catchAll in second", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.write(void 0),
-          Channel.concatMap(() => Channel.write(Channel.fail("error"))),
-          Channel.concatMap(Channel.catchAllCause(() => Channel.fail("error2"))),
-          Channel.runCollect,
-          Effect.exit
-        )
+        Channel.write(void 0),
+        Channel.concatMap(() => Channel.write(Channel.fail("error"))),
+        Channel.concatMap(Channel.catchAllCause(() => Channel.fail("error2"))),
+        Channel.runCollect,
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("error2"))
     }))
@@ -210,16 +188,14 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - done value combination", () =>
     Effect.gen(function*($) {
       const [chunk, [array1, array2]] = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3),
-          Channel.as(["Outer-0"]),
-          Channel.concatMapWith(
-            (i) => pipe(Channel.write(i), Channel.as([`Inner-${i}`])),
-            (a: Array<string>, b) => [...a, ...b],
-            (a, b) => [a, b] as const
-          ),
-          Channel.runCollect
-        )
+        Channel.writeAll(1, 2, 3),
+        Channel.as(["Outer-0"]),
+        Channel.concatMapWith(
+          (i) => pipe(Channel.write(i), Channel.as([`Inner-${i}`])),
+          (a: Array<string>, b) => [...a, ...b],
+          (a, b) => [a, b] as const
+        ),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), [1, 2, 3])
       assert.deepStrictEqual(array1, ["Inner-1", "Inner-2", "Inner-3"])
@@ -229,33 +205,31 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - custom 1", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3, 4),
-          Channel.concatMapWithCustom(
-            (x) =>
-              Channel.writeAll(
-                Option.some([x, 1]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 2]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 3]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 4]) as Option.Option<readonly [number, number]>
-              ),
-            constVoid,
-            constVoid,
-            UpstreamPullRequest.match({
-              onPulled: () => UpstreamPullStrategy.PullAfterNext(Option.none()),
-              onNoUpstream: () => UpstreamPullStrategy.PullAfterAllEnqueued(Option.none())
-            }),
-            Option.match({
-              onNone: () => ChildExecutorDecision.Yield(),
-              onSome: () => ChildExecutorDecision.Continue()
-            })
-          ),
-          Channel.runCollect,
-          Effect.map(([chunk]) => pipe(Array.from(chunk), ReadonlyArray.compact))
-        )
+        Channel.writeAll(1, 2, 3, 4),
+        Channel.concatMapWithCustom(
+          (x) =>
+            Channel.writeAll(
+              Option.some([x, 1]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 2]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 3]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 4]) as Option.Option<readonly [number, number]>
+            ),
+          constVoid,
+          constVoid,
+          UpstreamPullRequest.match({
+            onPulled: () => UpstreamPullStrategy.PullAfterNext(Option.none()),
+            onNoUpstream: () => UpstreamPullStrategy.PullAfterAllEnqueued(Option.none())
+          }),
+          Option.match({
+            onNone: () => ChildExecutorDecision.Yield(),
+            onSome: () => ChildExecutorDecision.Continue()
+          })
+        ),
+        Channel.runCollect,
+        Effect.map(([chunk]) => pipe(Array.from(chunk), ReadonlyArray.compact))
       )
       assert.deepStrictEqual(result, [
         [1, 1] as const,
@@ -280,30 +254,28 @@ describe.concurrent("Channel", () => {
   it.effect("concatMap - custom 2", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3, 4),
-          Channel.concatMapWithCustom(
-            (x) =>
-              Channel.writeAll(
-                Option.some([x, 1]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 2]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 3]) as Option.Option<readonly [number, number]>,
-                Option.none() as Option.Option<readonly [number, number]>,
-                Option.some([x, 4]) as Option.Option<readonly [number, number]>
-              ),
-            constVoid,
-            constVoid,
-            () => UpstreamPullStrategy.PullAfterAllEnqueued(Option.none()),
-            Option.match({
-              onNone: () => ChildExecutorDecision.Yield(),
-              onSome: () => ChildExecutorDecision.Continue()
-            })
-          ),
-          Channel.runCollect,
-          Effect.map(([chunk]) => pipe(Array.from(chunk), ReadonlyArray.compact))
-        )
+        Channel.writeAll(1, 2, 3, 4),
+        Channel.concatMapWithCustom(
+          (x) =>
+            Channel.writeAll(
+              Option.some([x, 1]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 2]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 3]) as Option.Option<readonly [number, number]>,
+              Option.none() as Option.Option<readonly [number, number]>,
+              Option.some([x, 4]) as Option.Option<readonly [number, number]>
+            ),
+          constVoid,
+          constVoid,
+          () => UpstreamPullStrategy.PullAfterAllEnqueued(Option.none()),
+          Option.match({
+            onNone: () => ChildExecutorDecision.Yield(),
+            onSome: () => ChildExecutorDecision.Continue()
+          })
+        ),
+        Channel.runCollect,
+        Effect.map(([chunk]) => pipe(Array.from(chunk), ReadonlyArray.compact))
       )
       assert.deepStrictEqual(result, [
         [1, 1] as const,

--- a/test/Channel/merging.ts
+++ b/test/Channel/merging.ts
@@ -13,16 +13,14 @@ describe.concurrent("Channel", () => {
   it.effect("mergeWith - simple merge", () =>
     Effect.gen(function*($) {
       const [chunk, value] = yield* $(
-        pipe(
-          Channel.writeAll(1, 2, 3),
-          Channel.mergeWith({
-            other: Channel.writeAll(4, 5, 6),
-            // TODO: remove
-            onSelfDone: (leftDone) => MergeDecision.AwaitConst(Effect.suspend(() => leftDone)),
-            onOtherDone: (rightDone) => MergeDecision.AwaitConst(Effect.suspend(() => rightDone))
-          }),
-          Channel.runCollect
-        )
+        Channel.writeAll(1, 2, 3),
+        Channel.mergeWith({
+          other: Channel.writeAll(4, 5, 6),
+          // TODO: remove
+          onSelfDone: (leftDone) => MergeDecision.AwaitConst(Effect.suspend(() => leftDone)),
+          onOtherDone: (rightDone) => MergeDecision.AwaitConst(Effect.suspend(() => rightDone))
+        }),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), [1, 2, 3, 4, 5, 6])
       assert.isUndefined(value)
@@ -59,18 +57,16 @@ describe.concurrent("Channel", () => {
         )
       )
       const [chunk, value] = yield* $(
-        pipe(
-          left,
-          Channel.mergeWith({
-            other: right,
-            // TODO: remove
-            onSelfDone: (leftDone) =>
-              MergeDecision.Await((rightDone) => Effect.suspend(() => Exit.zip(leftDone, rightDone))),
-            onOtherDone: (rightDone) =>
-              MergeDecision.Await((leftDone) => Effect.suspend(() => Exit.zip(leftDone, rightDone)))
-          }),
-          Channel.runCollect
-        )
+        left,
+        Channel.mergeWith({
+          other: right,
+          // TODO: remove
+          onSelfDone: (leftDone) =>
+            MergeDecision.Await((rightDone) => Effect.suspend(() => Exit.zip(leftDone, rightDone))),
+          onOtherDone: (rightDone) =>
+            MergeDecision.Await((leftDone) => Effect.suspend(() => Exit.zip(leftDone, rightDone)))
+        }),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), [1, 2])
       assert.deepStrictEqual(value, ["whatever", true])
@@ -86,7 +82,7 @@ describe.concurrent("Channel", () => {
         Channel.write(2),
         Channel.zipRight(pipe(Channel.fail(true), Channel.as(true)))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         left,
         Channel.mergeWith({
           other: right,
@@ -115,7 +111,7 @@ describe.concurrent("Channel", () => {
         }),
         Channel.runDrain,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail<[string, boolean]>(["boom", true]))
     }))
 

--- a/test/Channel/reading.ts
+++ b/test/Channel/reading.ts
@@ -178,7 +178,7 @@ describe.concurrent("Channel", () => {
           )
         )
       )
-      const result = yield* $(pipe(Channel.run(channel), Effect.zipRight(Ref.get(ref))))
+      const result = yield* $(Channel.run(channel), Effect.zipRight(Ref.get(ref)))
       assert.deepStrictEqual(result, [3, 7])
     }))
 
@@ -215,7 +215,7 @@ describe.concurrent("Channel", () => {
         Channel.catchAll(() => Channel.unit)
       )
       const channel = pipe(left, Channel.pipeTo(right))
-      const result = yield* $(pipe(Channel.runDrain(channel), Effect.zipRight(Ref.get(ref))))
+      const result = yield* $(Channel.runDrain(channel), Effect.zipRight(Ref.get(ref)))
       assert.deepStrictEqual(Array.from(result), [
         "Acquire outer",
         "Acquire 1",
@@ -243,23 +243,21 @@ describe.concurrent("Channel", () => {
         })
       )
       const [missing, surplus] = yield* $(
-        pipe(
-          refReader(source),
-          Channel.pipeTo(twoWriters),
-          Channel.mapEffect(() => Ref.get(destination)),
-          Channel.run,
-          Effect.map((result) => {
-            let missing = HashSet.fromIterable(elements)
-            let surplus = HashSet.fromIterable(result)
-            for (const value of result) {
-              missing = pipe(missing, HashSet.remove(value))
-            }
-            for (const value of elements) {
-              surplus = pipe(surplus, HashSet.remove(value))
-            }
-            return [missing, surplus] as const
-          })
-        )
+        refReader(source),
+        Channel.pipeTo(twoWriters),
+        Channel.mapEffect(() => Ref.get(destination)),
+        Channel.run,
+        Effect.map((result) => {
+          let missing = HashSet.fromIterable(elements)
+          let surplus = HashSet.fromIterable(result)
+          for (const value of result) {
+            missing = pipe(missing, HashSet.remove(value))
+          }
+          for (const value of elements) {
+            surplus = pipe(surplus, HashSet.remove(value))
+          }
+          return [missing, surplus] as const
+        })
       )
 
       assert.strictEqual(HashSet.size(missing), 0)
@@ -283,24 +281,22 @@ describe.concurrent("Channel", () => {
         })
       )
       const [missing, surplus] = yield* $(
-        pipe(
-          refReader(source),
-          Channel.pipeTo(twoWriters),
-          Channel.mapEffect(() => Ref.get(destination)),
-          Channel.run,
-          Effect.map((result) => {
-            const expected = HashSet.fromIterable(elements.map(f))
-            let missing = HashSet.fromIterable(expected)
-            let surplus = HashSet.fromIterable(result)
-            for (const value of result) {
-              missing = pipe(missing, HashSet.remove(value))
-            }
-            for (const value of expected) {
-              surplus = pipe(surplus, HashSet.remove(value))
-            }
-            return [missing, surplus] as const
-          })
-        )
+        refReader(source),
+        Channel.pipeTo(twoWriters),
+        Channel.mapEffect(() => Ref.get(destination)),
+        Channel.run,
+        Effect.map((result) => {
+          const expected = HashSet.fromIterable(elements.map(f))
+          let missing = HashSet.fromIterable(expected)
+          let surplus = HashSet.fromIterable(result)
+          for (const value of result) {
+            missing = pipe(missing, HashSet.remove(value))
+          }
+          for (const value of expected) {
+            surplus = pipe(surplus, HashSet.remove(value))
+          }
+          return [missing, surplus] as const
+        })
       )
       assert.strictEqual(HashSet.size(missing), 0)
       assert.strictEqual(HashSet.size(surplus), 0)

--- a/test/Channel/stack-safety.ts
+++ b/test/Channel/stack-safety.ts
@@ -10,14 +10,12 @@ describe.concurrent("Channel", () => {
     Effect.gen(function*($) {
       const N = 10_000
       const [chunk, value] = yield* $(
-        pipe(
-          Chunk.range(1, N),
-          Chunk.reduce(
-            Channel.write<number>(1),
-            (channel, n) => pipe(channel, Channel.mapOut((i) => i + n))
-          ),
-          Channel.runCollect
-        )
+        Chunk.range(1, N),
+        Chunk.reduce(
+          Channel.write<number>(1),
+          (channel, n) => pipe(channel, Channel.mapOut((i) => i + n))
+        ),
+        Channel.runCollect
       )
       const expected = pipe(
         Chunk.range(1, N),
@@ -31,19 +29,17 @@ describe.concurrent("Channel", () => {
     Effect.gen(function*($) {
       const N = 10_000
       const [chunk, value] = yield* $(
-        pipe(
-          Chunk.range(1, N),
-          Chunk.reduce(
-            Channel.write<number>(1),
-            (channel, n) =>
-              pipe(
-                channel,
-                Channel.concatMap(() => Channel.write(n)),
-                Channel.asUnit
-              )
-          ),
-          Channel.runCollect
-        )
+        Chunk.range(1, N),
+        Chunk.reduce(
+          Channel.write<number>(1),
+          (channel, n) =>
+            pipe(
+              channel,
+              Channel.concatMap(() => Channel.write(n)),
+              Channel.asUnit
+            )
+        ),
+        Channel.runCollect
       )
       assert.strictEqual(Chunk.unsafeHead(chunk), N)
       assert.isUndefined(value)
@@ -53,14 +49,12 @@ describe.concurrent("Channel", () => {
     Effect.gen(function*($) {
       const N = 10_000
       const [chunk, value] = yield* $(
-        pipe(
-          Chunk.range(1, N),
-          Chunk.reduce(
-            Channel.write<number>(0),
-            (channel, n) => pipe(channel, Channel.flatMap(() => Channel.write(n)))
-          ),
-          Channel.runCollect
-        )
+        Chunk.range(1, N),
+        Chunk.reduce(
+          Channel.write<number>(0),
+          (channel, n) => pipe(channel, Channel.flatMap(() => Channel.write(n)))
+        ),
+        Channel.runCollect
       )
       assert.deepStrictEqual(Array.from(chunk), Array.from(Chunk.range(0, N)))
       assert.isUndefined(value)

--- a/test/Sink/collecting.ts
+++ b/test/Sink/collecting.ts
@@ -50,7 +50,7 @@ describe.concurrent("Sink", () => {
   it.effect("collectAllToSet", () =>
     Effect.gen(function*($) {
       const stream = Stream.make(1, 2, 3, 3, 4)
-      const result = yield* $(pipe(stream, Stream.run(Sink.collectAllToSet())))
+      const result = yield* $(stream, Stream.run(Sink.collectAllToSet()))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4])
     }))
 
@@ -83,13 +83,11 @@ describe.concurrent("Sink", () => {
   it.effect("collectAllToMap", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(0, 10),
-          Stream.run(Sink.collectAllToMap(
-            (n) => n % 3,
-            (x, y) => x + y
-          ))
-        )
+        Stream.range(0, 10),
+        Stream.run(Sink.collectAllToMap(
+          (n) => n % 3,
+          (x, y) => x + y
+        ))
       )
       assert.deepStrictEqual(
         Array.from(result),
@@ -100,15 +98,13 @@ describe.concurrent("Sink", () => {
   it.effect("collectAllToMapN - respects the given limit", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 1, 2, 2, 3, 2, 4, 5),
-          Stream.transduce(Sink.collectAllToMapN(
-            2,
-            (n) => n % 3,
-            (x, y) => x + y
-          )),
-          Stream.runCollect
-        )
+        Stream.make(1, 1, 2, 2, 3, 2, 4, 5),
+        Stream.transduce(Sink.collectAllToMapN(
+          2,
+          (n) => n % 3,
+          (x, y) => x + y
+        )),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(Chunk.map(result, (chunk) => Array.from(chunk))),
@@ -119,15 +115,13 @@ describe.concurrent("Sink", () => {
   it.effect("collectAllToMapN - collects as long as map size doesn't exceed the limit", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunks(Chunk.make(0, 1, 2), Chunk.make(3, 4, 5), Chunk.make(6, 7, 8, 9)),
-          Stream.transduce(Sink.collectAllToMapN(
-            3,
-            (n) => n % 3,
-            (x, y) => x + y
-          )),
-          Stream.runCollect
-        )
+        Stream.fromChunks(Chunk.make(0, 1, 2), Chunk.make(3, 4, 5), Chunk.make(6, 7, 8, 9)),
+        Stream.transduce(Sink.collectAllToMapN(
+          3,
+          (n) => n % 3,
+          (x, y) => x + y
+        )),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(Chunk.map(result, (chunk) => Array.from(chunk))),
@@ -138,15 +132,13 @@ describe.concurrent("Sink", () => {
   it.effect("collectAllToMapN - handles empty input", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunk(Chunk.empty<number>()),
-          Stream.transduce(Sink.collectAllToMapN(
-            3,
-            (n) => n % 3,
-            (x, y) => x + y
-          )),
-          Stream.runCollect
-        )
+        Stream.fromChunk(Chunk.empty<number>()),
+        Stream.transduce(Sink.collectAllToMapN(
+          3,
+          (n) => n % 3,
+          (x, y) => x + y
+        )),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(Chunk.map(result, (chunk) => Array.from(chunk))),
@@ -163,7 +155,7 @@ describe.concurrent("Sink", () => {
         Chunk.make(3, 4, 5, 6, 5, 4, 3, 2),
         Chunk.empty<number>()
       )
-      const result = yield* $(pipe(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect))
+      const result = yield* $(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect)
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[3, 4, 5], [6], [7], [2, 3, 4, 5], [6], [5], [4, 3, 2]]
@@ -179,7 +171,7 @@ describe.concurrent("Sink", () => {
         Chunk.make(3, 4, 5, 6, 5, 4, 3, 2),
         Chunk.empty<number>()
       )
-      const result = yield* $(pipe(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect))
+      const result = yield* $(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect)
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[3, 4, 5], [6], [7], [2, 3, 4, 5], [6], [5], [4, 3, 2]]
@@ -198,7 +190,7 @@ describe.concurrent("Sink", () => {
         Chunk.make(3, 4, 5, 6, 5, 4, 3, 2),
         Chunk.empty<number>()
       )
-      const result = yield* $(pipe(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect))
+      const result = yield* $(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect)
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[3, 4], [2, 3, 4], [4, 3, 2]]
@@ -217,7 +209,7 @@ describe.concurrent("Sink", () => {
         Chunk.make(3, 4, 5, 6, 5, 4, 3, 2),
         Chunk.empty<number>()
       )
-      const result = yield* $(pipe(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect))
+      const result = yield* $(Stream.fromChunks(...input), Stream.transduce(sink), Stream.runCollect)
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[3, 4], [2, 3, 4], [4, 3, 2]]
@@ -261,12 +253,12 @@ describe.concurrent("Sink", () => {
         })
       )
       const stream = pipe(Stream.fromChunk(Chunk.range(1, 100)))
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.concat(stream),
         Stream.rechunk(3),
         Stream.run(sink)
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4])
     }))
 })

--- a/test/Sink/dropping.ts
+++ b/test/Sink/dropping.ts
@@ -1,5 +1,4 @@
 import * as Either from "@effect/data/Either"
-import { pipe } from "@effect/data/Function"
 import * as Effect from "@effect/io/Effect"
 import * as Sink from "@effect/stream/Sink"
 import * as Stream from "@effect/stream/Stream"
@@ -10,11 +9,9 @@ describe.concurrent("Sink", () => {
   it.effect("dropUntil", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
-          Stream.pipeThrough(Sink.dropUntil<number>((n) => n >= 3)),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
+        Stream.pipeThrough(Sink.dropUntil<number>((n) => n >= 3)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [4, 5, 1, 2, 3, 4, 5])
     }))
@@ -22,11 +19,9 @@ describe.concurrent("Sink", () => {
   it.effect("dropUntilEffect - happy path", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
-          Stream.pipeThrough(Sink.dropUntilEffect((n) => Effect.succeed(n >= 3))),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
+        Stream.pipeThrough(Sink.dropUntilEffect((n) => Effect.succeed(n >= 3))),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [4, 5, 1, 2, 3, 4, 5])
     }))
@@ -34,14 +29,12 @@ describe.concurrent("Sink", () => {
   it.effect("dropUntilEffect - error", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3),
-          Stream.concat(Stream.fail("Aie")),
-          Stream.concat(Stream.make(5, 1, 2, 3, 4, 5)),
-          Stream.pipeThrough(Sink.dropUntilEffect((n) => Effect.succeed(n >= 2))),
-          Stream.either,
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3),
+        Stream.concat(Stream.fail("Aie")),
+        Stream.concat(Stream.make(5, 1, 2, 3, 4, 5)),
+        Stream.pipeThrough(Sink.dropUntilEffect((n) => Effect.succeed(n >= 2))),
+        Stream.either,
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [Either.right(3), Either.left("Aie")])
     }))
@@ -49,11 +42,9 @@ describe.concurrent("Sink", () => {
   it.effect("dropWhile", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
-          Stream.pipeThrough(Sink.dropWhile<number>((n) => n < 3)),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
+        Stream.pipeThrough(Sink.dropWhile<number>((n) => n < 3)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [3, 4, 5, 1, 2, 3, 4, 5])
     }))
@@ -61,11 +52,9 @@ describe.concurrent("Sink", () => {
   it.effect("dropWhileEffect - happy path", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
-          Stream.pipeThrough(Sink.dropWhileEffect((n) => Effect.succeed(n < 3))),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3, 4, 5, 1, 2, 3, 4, 5),
+        Stream.pipeThrough(Sink.dropWhileEffect((n) => Effect.succeed(n < 3))),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [3, 4, 5, 1, 2, 3, 4, 5])
     }))
@@ -73,16 +62,14 @@ describe.concurrent("Sink", () => {
   it.effect("dropWhileEffect - error", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.concat(
-            Stream.make(1, 2, 3),
-            Stream.fail("Aie")
-          ),
-          Stream.concat(Stream.make(5, 1, 2, 3, 4, 5)),
-          Stream.pipeThrough(Sink.dropWhileEffect((n) => Effect.succeed(n < 3))),
-          Stream.either,
-          Stream.runCollect
-        )
+        Stream.concat(
+          Stream.make(1, 2, 3),
+          Stream.fail("Aie")
+        ),
+        Stream.concat(Stream.make(5, 1, 2, 3, 4, 5)),
+        Stream.pipeThrough(Sink.dropWhileEffect((n) => Effect.succeed(n < 3))),
+        Stream.either,
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [Either.right(3), Either.left("Aie")])
     }))

--- a/test/Sink/elements.ts
+++ b/test/Sink/elements.ts
@@ -13,10 +13,8 @@ describe.concurrent("Sink", () => {
       const chunk = Chunk.make(1, 2, 3, 4, 5)
       const predicate = (n: number) => n < 6
       const result = yield* $(
-        pipe(
-          Stream.fromChunk(chunk),
-          Stream.run(Sink.every(predicate))
-        )
+        Stream.fromChunk(chunk),
+        Stream.run(Sink.every(predicate))
       )
       assert.isTrue(result)
     }))
@@ -24,10 +22,8 @@ describe.concurrent("Sink", () => {
   it.effect("head", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunks(Chunk.range(1, 10), Chunk.range(1, 3), Chunk.range(2, 5)),
-          Stream.run(Sink.head())
-        )
+        Stream.fromChunks(Chunk.range(1, 10), Chunk.range(1, 3), Chunk.range(2, 5)),
+        Stream.run(Sink.head())
       )
       assert.deepStrictEqual(result, Option.some(1))
     }))
@@ -35,10 +31,8 @@ describe.concurrent("Sink", () => {
   it.effect("last", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunks(Chunk.range(1, 10), Chunk.range(1, 3), Chunk.range(2, 5)),
-          Stream.run(Sink.last())
-        )
+        Stream.fromChunks(Chunk.range(1, 10), Chunk.range(1, 3), Chunk.range(2, 5)),
+        Stream.run(Sink.last())
       )
       assert.deepStrictEqual(result, Option.some(5))
     }))
@@ -46,16 +40,14 @@ describe.concurrent("Sink", () => {
   it.effect("take - repeats until the source is exhausted", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunks(
-            Chunk.make(1, 2),
-            Chunk.make(3, 4, 5),
-            Chunk.empty<number>(),
-            Chunk.make(6, 7),
-            Chunk.make(8, 9)
-          ),
-          Stream.run(Sink.collectAllFrom(Sink.take<number>(3)))
-        )
+        Stream.fromChunks(
+          Chunk.make(1, 2),
+          Chunk.make(3, 4, 5),
+          Chunk.empty<number>(),
+          Chunk.make(6, 7),
+          Chunk.make(8, 9)
+        ),
+        Stream.run(Sink.collectAllFrom(Sink.take<number>(3)))
       )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
@@ -68,10 +60,8 @@ describe.concurrent("Sink", () => {
       const chunk = Chunk.make(1, 2, 3, 4, 5)
       const predicate = (n: number) => n === 3
       const result = yield* $(
-        pipe(
-          Stream.fromChunk(chunk),
-          Stream.run(Sink.some(predicate))
-        )
+        Stream.fromChunk(chunk),
+        Stream.run(Sink.some(predicate))
       )
       assert.isTrue(result)
     }))
@@ -79,19 +69,17 @@ describe.concurrent("Sink", () => {
   it.effect("sum", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.fromChunks(
-            Chunk.make(1, 2),
-            Chunk.make(3, 4, 5),
-            Chunk.empty<number>(),
-            Chunk.make(6, 7),
-            Chunk.make(8, 9)
-          ),
-          Stream.run(pipe(
-            Sink.collectAllFrom(Sink.sum),
-            Sink.map(Chunk.reduce(0, (x, y) => x + y))
-          ))
-        )
+        Stream.fromChunks(
+          Chunk.make(1, 2),
+          Chunk.make(3, 4, 5),
+          Chunk.empty<number>(),
+          Chunk.make(6, 7),
+          Chunk.make(8, 9)
+        ),
+        Stream.run(pipe(
+          Sink.collectAllFrom(Sink.sum),
+          Sink.map(Chunk.reduce(0, (x, y) => x + y))
+        ))
       )
       assert.strictEqual(result, 45)
     }))
@@ -107,17 +95,15 @@ describe.concurrent("Sink", () => {
         Chunk.make(8, 9)
       )
       const [chunk, leftover] = yield* $(
-        pipe(
-          Stream.fromChunks(...chunks),
-          Stream.peel(Sink.take<number>(n)),
-          Effect.flatMap(([chunk, stream]) =>
-            pipe(
-              Stream.runCollect(stream),
-              Effect.map((leftover) => [chunk, leftover] as const)
-            )
-          ),
-          Effect.scoped
-        )
+        Stream.fromChunks(...chunks),
+        Stream.peel(Sink.take<number>(n)),
+        Effect.flatMap(([chunk, stream]) =>
+          pipe(
+            Stream.runCollect(stream),
+            Effect.map((leftover) => [chunk, leftover] as const)
+          )
+        ),
+        Effect.scoped
       )
       assert.deepStrictEqual(
         Array.from(chunk),

--- a/test/Sink/environment.ts
+++ b/test/Sink/environment.ts
@@ -14,7 +14,7 @@ describe.concurrent("Sink", () => {
         Sink.contextWithSink((env: Context.Context<string>) => Sink.succeed(pipe(env, Context.get(tag)))),
         Sink.provideContext(pipe(Context.empty(), Context.add(tag, "use this")))
       )
-      const result = yield* $(pipe(Stream.make("ignore this"), Stream.run(sink)))
+      const result = yield* $(Stream.make("ignore this"), Stream.run(sink))
       assert.strictEqual(result, "use this")
     }))
 })

--- a/test/Sink/error-handling.ts
+++ b/test/Sink/error-handling.ts
@@ -13,18 +13,16 @@ describe.concurrent("Sink", () => {
       const ErrorMapped = "ErrorMapped" as const
       const ErrorSink = "ErrorSink" as const
       const result = yield* $(
-        pipe(
-          Stream.fail(ErrorStream),
-          Stream.mapError(() => ErrorMapped),
-          Stream.run(
-            pipe(
-              Sink.drain,
-              Sink.contramapEffect((input: number) => Effect.try(() => input)),
-              Sink.mapError(() => ErrorSink)
-            )
-          ),
-          Effect.exit
-        )
+        Stream.fail(ErrorStream),
+        Stream.mapError(() => ErrorMapped),
+        Stream.run(
+          pipe(
+            Sink.drain,
+            Sink.contramapEffect((input: number) => Effect.try(() => input)),
+            Sink.mapError(() => ErrorSink)
+          )
+        ),
+        Effect.exit
       )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(ErrorMapped))
     }))

--- a/test/Sink/filtering.ts
+++ b/test/Sink/filtering.ts
@@ -9,10 +9,8 @@ describe.concurrent("Sink", () => {
   it.effect("filterInput", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.collectAll<number>(), Sink.filterInput((n) => n % 2 === 0)))
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.collectAll<number>(), Sink.filterInput((n) => n % 2 === 0)))
       )
       assert.deepStrictEqual(Array.from(result), [2, 4, 6, 8])
     }))
@@ -20,13 +18,11 @@ describe.concurrent("Sink", () => {
   it.effect("filterInputEffect - happy path", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(
-            Sink.collectAll<number>(),
-            Sink.filterInputEffect((n) => Effect.succeed(n % 2 === 0))
-          ))
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(
+          Sink.collectAll<number>(),
+          Sink.filterInputEffect((n) => Effect.succeed(n % 2 === 0))
+        ))
       )
       assert.deepStrictEqual(Array.from(result), [2, 4, 6, 8])
     }))
@@ -34,14 +30,12 @@ describe.concurrent("Sink", () => {
   it.effect("filterInputEffect - error", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(
-            Sink.collectAll<number>(),
-            Sink.filterInputEffect(() => Effect.fail("fail"))
-          )),
-          Effect.flip
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(
+          Sink.collectAll<number>(),
+          Sink.filterInputEffect(() => Effect.fail("fail"))
+        )),
+        Effect.flip
       )
       assert.strictEqual(result, "fail")
     }))

--- a/test/Sink/finalization.ts
+++ b/test/Sink/finalization.ts
@@ -11,10 +11,8 @@ describe.concurrent("Sink", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
       yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4, 5),
-          Stream.run(pipe(Sink.drain, Sink.ensuring(Ref.set(ref, true))))
-        )
+        Stream.make(1, 2, 3, 4, 5),
+        Stream.run(pipe(Sink.drain, Sink.ensuring(Ref.set(ref, true))))
       )
       const result = yield* $(Ref.get(ref))
       assert.isTrue(result)
@@ -24,11 +22,9 @@ describe.concurrent("Sink", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
       yield* $(
-        pipe(
-          Stream.fail("boom!"),
-          Stream.run(pipe(Sink.drain, Sink.ensuring(Ref.set(ref, true)))),
-          Effect.ignore
-        )
+        Stream.fail("boom!"),
+        Stream.run(pipe(Sink.drain, Sink.ensuring(Ref.set(ref, true)))),
+        Effect.ignore
       )
       const result = yield* $(Ref.get(ref))
       assert.isTrue(result)

--- a/test/Sink/folding.ts
+++ b/test/Sink/folding.ts
@@ -12,11 +12,9 @@ describe.concurrent("Sink", () => {
   it.effect("fold - empty", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.empty,
-          Stream.transduce(Sink.fold<number, number>(0, constTrue, (x, y) => x + y)),
-          Stream.runCollect
-        )
+        Stream.empty,
+        Stream.transduce(Sink.fold<number, number>(0, constTrue, (x, y) => x + y)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [0])
     }))
@@ -24,10 +22,8 @@ describe.concurrent("Sink", () => {
   it.effect("fold - termination in the middle", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(Sink.fold<number, number>(0, (n) => n <= 5, (x, y) => x + y))
-        )
+        Stream.range(1, 10),
+        Stream.run(Sink.fold<number, number>(0, (n) => n <= 5, (x, y) => x + y))
       )
       assert.strictEqual(result, 6)
     }))
@@ -35,10 +31,8 @@ describe.concurrent("Sink", () => {
   it.effect("fold - immediate termination", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(Sink.fold<number, number>(0, (n) => n <= -1, (x, y) => x + y))
-        )
+        Stream.range(1, 10),
+        Stream.run(Sink.fold<number, number>(0, (n) => n <= -1, (x, y) => x + y))
       )
       assert.strictEqual(result, 0)
     }))
@@ -46,10 +40,8 @@ describe.concurrent("Sink", () => {
   it.effect("fold - no termination", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(Sink.fold<number, number>(0, (n) => n <= 500, (x, y) => x + y))
-        )
+        Stream.range(1, 10),
+        Stream.run(Sink.fold<number, number>(0, (n) => n <= 500, (x, y) => x + y))
       )
       assert.strictEqual(result, 45)
     }))
@@ -57,15 +49,15 @@ describe.concurrent("Sink", () => {
   it.effect("foldLeft equivalence with Chunk.reduce", () =>
     Effect.gen(function*($) {
       const stream = Stream.range(1, 10)
-      const result1 = yield* $(pipe(stream, Stream.run(Sink.foldLeft("", (s, n) => s + `${n}`))))
-      const result2 = yield* $(pipe(stream, Stream.runCollect, Effect.map(Chunk.reduce("", (s, n) => s + `${n}`))))
+      const result1 = yield* $(stream, Stream.run(Sink.foldLeft("", (s, n) => s + `${n}`)))
+      const result2 = yield* $(stream, Stream.runCollect, Effect.map(Chunk.reduce("", (s, n) => s + `${n}`)))
       assert.strictEqual(result1, result2)
     }))
 
   it.effect("foldEffect - empty", () =>
     Effect.gen(function*($) {
       const sink = Sink.foldEffect(0, constTrue, (x, y: number) => Effect.succeed(x + y))
-      const result = yield* $(pipe(Stream.empty, Stream.transduce(sink), Stream.runCollect))
+      const result = yield* $(Stream.empty, Stream.transduce(sink), Stream.runCollect)
       assert.deepStrictEqual(Array.from(result), [0])
     }))
 
@@ -110,11 +102,9 @@ describe.concurrent("Sink", () => {
   it.effect("foldUntil", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 1, 1, 1, 1, 1),
-          Stream.transduce(Sink.foldUntil(0, 3, (x, y) => x + y)),
-          Stream.runCollect
-        )
+        Stream.make(1, 1, 1, 1, 1, 1),
+        Stream.transduce(Sink.foldUntil(0, 3, (x, y) => x + y)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [3, 3, 0])
     }))
@@ -122,11 +112,9 @@ describe.concurrent("Sink", () => {
   it.effect("foldUntilEffect", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 1, 1, 1, 1, 1),
-          Stream.transduce(Sink.foldUntilEffect(0, 3, (x, y) => Effect.succeed(x + y))),
-          Stream.runCollect
-        )
+        Stream.make(1, 1, 1, 1, 1, 1),
+        Stream.transduce(Sink.foldUntilEffect(0, 3, (x, y) => Effect.succeed(x + y))),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [3, 3, 0])
     }))
@@ -134,16 +122,14 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeighted", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 5, 2, 3),
-          Stream.transduce(Sink.foldWeighted({
-            initial: Chunk.empty<number>(),
-            maxCost: 12,
-            cost: (_, n) => n * 2,
-            body: (acc, curr) => pipe(acc, Chunk.append(curr))
-          })),
-          Stream.runCollect
-        )
+        Stream.make(1, 5, 2, 3),
+        Stream.transduce(Sink.foldWeighted({
+          initial: Chunk.empty<number>(),
+          maxCost: 12,
+          cost: (_, n) => n * 2,
+          body: (acc, curr) => pipe(acc, Chunk.append(curr))
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
@@ -154,17 +140,15 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeightedDecompose - empty", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.empty,
-          Stream.transduce(Sink.foldWeightedDecompose({
-            initial: 0,
-            maxCost: 1_000,
-            cost: (_, n) => n,
-            decompose: Chunk.of,
-            body: (acc, curr) => acc + curr
-          })),
-          Stream.runCollect
-        )
+        Stream.empty,
+        Stream.transduce(Sink.foldWeightedDecompose({
+          initial: 0,
+          maxCost: 1_000,
+          cost: (_, n) => n,
+          decompose: Chunk.of,
+          body: (acc, curr) => acc + curr
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [0])
     }))
@@ -172,17 +156,15 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeightedDecompose - simple", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 5, 1),
-          Stream.transduce(Sink.foldWeightedDecompose({
-            initial: Chunk.empty<number>(),
-            maxCost: 4,
-            cost: (_, n) => n,
-            decompose: (n) => n > 1 ? Chunk.make(n - 1, 1) : Chunk.of(n),
-            body: (acc, curr) => pipe(acc, Chunk.append(curr))
-          })),
-          Stream.runCollect
-        )
+        Stream.make(1, 5, 1),
+        Stream.transduce(Sink.foldWeightedDecompose({
+          initial: Chunk.empty<number>(),
+          maxCost: 4,
+          cost: (_, n) => n,
+          decompose: (n) => n > 1 ? Chunk.make(n - 1, 1) : Chunk.of(n),
+          body: (acc, curr) => pipe(acc, Chunk.append(curr))
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
@@ -193,16 +175,14 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeightedEffect", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 5, 2, 3),
-          Stream.transduce(Sink.foldWeightedEffect({
-            initial: Chunk.empty<number>(),
-            maxCost: 12,
-            cost: (_, n) => Effect.succeed(n * 2),
-            body: (acc, curr) => Effect.succeed(pipe(acc, Chunk.append(curr)))
-          })),
-          Stream.runCollect
-        )
+        Stream.make(1, 5, 2, 3),
+        Stream.transduce(Sink.foldWeightedEffect({
+          initial: Chunk.empty<number>(),
+          maxCost: 12,
+          cost: (_, n) => Effect.succeed(n * 2),
+          body: (acc, curr) => Effect.succeed(pipe(acc, Chunk.append(curr)))
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
@@ -213,17 +193,15 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeightedDecomposeEffect - empty", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.empty,
-          Stream.transduce(Sink.foldWeightedDecomposeEffect({
-            initial: 0,
-            maxCost: 1_000,
-            cost: (_, n) => Effect.succeed(n),
-            decompose: (input) => Effect.succeed(Chunk.of(input)),
-            body: (acc, curr) => Effect.succeed(acc + curr)
-          })),
-          Stream.runCollect
-        )
+        Stream.empty,
+        Stream.transduce(Sink.foldWeightedDecomposeEffect({
+          initial: 0,
+          maxCost: 1_000,
+          cost: (_, n) => Effect.succeed(n),
+          decompose: (input) => Effect.succeed(Chunk.of(input)),
+          body: (acc, curr) => Effect.succeed(acc + curr)
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [0])
     }))
@@ -231,17 +209,15 @@ describe.concurrent("Sink", () => {
   it.effect("foldWeightedDecomposeEffect - simple", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 5, 1),
-          Stream.transduce(Sink.foldWeightedDecomposeEffect({
-            initial: Chunk.empty<number>(),
-            maxCost: 4,
-            cost: (_, n) => Effect.succeed(n),
-            decompose: (n) => Effect.succeed(n > 1 ? Chunk.make(n - 1, 1) : Chunk.of(n)),
-            body: (acc, curr) => Effect.succeed(pipe(acc, Chunk.append(curr)))
-          })),
-          Stream.runCollect
-        )
+        Stream.make(1, 5, 1),
+        Stream.transduce(Sink.foldWeightedDecomposeEffect({
+          initial: Chunk.empty<number>(),
+          maxCost: 4,
+          cost: (_, n) => Effect.succeed(n),
+          decompose: (n) => Effect.succeed(n > 1 ? Chunk.make(n - 1, 1) : Chunk.of(n)),
+          body: (acc, curr) => Effect.succeed(pipe(acc, Chunk.append(curr)))
+        })),
+        Stream.runCollect
       )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
@@ -263,10 +239,8 @@ describe.concurrent("Sink", () => {
         })
       )
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3),
-          Stream.run(sink)
-        )
+        Stream.make(1, 2, 3),
+        Stream.run(sink)
       )
       assert.deepStrictEqual(result, [[1, 2, 3], "boom"])
     }))

--- a/test/Sink/mapping.ts
+++ b/test/Sink/mapping.ts
@@ -12,10 +12,8 @@ describe.concurrent("Sink", () => {
   it.effect("as", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.succeed(1), Sink.as("as")))
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.succeed(1), Sink.as("as")))
       )
       assert.strictEqual(result, "as")
     }))
@@ -26,7 +24,7 @@ describe.concurrent("Sink", () => {
         Sink.collectAll<number>(),
         Sink.contramap((input: string) => Number.parseInt(input))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink)))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
@@ -36,7 +34,7 @@ describe.concurrent("Sink", () => {
         Sink.fail("Ouch"),
         Sink.contramap((input: string) => Number.parseInt(input))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -46,7 +44,7 @@ describe.concurrent("Sink", () => {
         Sink.collectAll<number>(),
         Sink.contramapChunks<string, number>(Chunk.map((_) => Number.parseInt(_)))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink)))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
@@ -56,7 +54,7 @@ describe.concurrent("Sink", () => {
         Sink.fail("Ouch"),
         Sink.contramapChunks<string, number>(Chunk.map(Number.parseInt))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -66,7 +64,7 @@ describe.concurrent("Sink", () => {
         Sink.collectAll<number>(),
         Sink.contramapEffect((s: string) => Effect.try(() => Number.parseInt(s)))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink)))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
@@ -76,7 +74,7 @@ describe.concurrent("Sink", () => {
         Sink.fail("Ouch"),
         Sink.contramapEffect((s: string) => Effect.try(() => Number.parseInt(s)))
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -94,7 +92,7 @@ describe.concurrent("Sink", () => {
           })
         )
       )
-      const result = yield* $(pipe(Stream.make("1", "a"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "a"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left(Cause.RuntimeException("Cannot parse \"a\" to an integer")))
     }))
 
@@ -110,7 +108,7 @@ describe.concurrent("Sink", () => {
           )
         )
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink)))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
@@ -126,7 +124,7 @@ describe.concurrent("Sink", () => {
           )
         )
       )
-      const result = yield* $(pipe(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -150,17 +148,15 @@ describe.concurrent("Sink", () => {
           )
         )
       )
-      const result = yield* $(pipe(Stream.make("1", "a"), Stream.run(sink), Effect.either))
+      const result = yield* $(Stream.make("1", "a"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left(Cause.RuntimeException("Cannot parse \"a\" to an integer")))
     }))
 
   it.effect("map", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.succeed(1), Sink.map((n) => `${n}`)))
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.succeed(1), Sink.map((n) => `${n}`)))
       )
       assert.strictEqual(result, "1")
     }))
@@ -168,10 +164,8 @@ describe.concurrent("Sink", () => {
   it.effect("mapEffect - happy path", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.succeed(1), Sink.mapEffect((n) => Effect.succeed(n + 1))))
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.succeed(1), Sink.mapEffect((n) => Effect.succeed(n + 1))))
       )
       assert.strictEqual(result, 2)
     }))
@@ -179,11 +173,9 @@ describe.concurrent("Sink", () => {
   it.effect("mapEffect - error", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.succeed(1), Sink.mapEffect(() => Effect.fail("fail")))),
-          Effect.flip
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.succeed(1), Sink.mapEffect(() => Effect.fail("fail")))),
+        Effect.flip
       )
       assert.strictEqual(result, "fail")
     }))
@@ -191,11 +183,9 @@ describe.concurrent("Sink", () => {
   it.effect("mapError", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(1, 10),
-          Stream.run(pipe(Sink.fail("fail"), Sink.mapError((s) => s + "!"))),
-          Effect.either
-        )
+        Stream.range(1, 10),
+        Stream.run(pipe(Sink.fail("fail"), Sink.mapError((s) => s + "!"))),
+        Effect.either
       )
       assert.deepStrictEqual(result, Either.left("fail!"))
     }))

--- a/test/Sink/refining.ts
+++ b/test/Sink/refining.ts
@@ -21,7 +21,7 @@ describe.concurrent("Sink", () => {
             Option.none()
         )
       )
-      const result = yield* $(pipe(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit))
+      const result = yield* $(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit)
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(refinedTo))
     }))
 
@@ -36,7 +36,7 @@ describe.concurrent("Sink", () => {
             Option.some(refinedTo) :
             Option.none(), (error) => error.message)
       )
-      const result = yield* $(pipe(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit))
+      const result = yield* $(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit)
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(refinedTo))
     }))
 
@@ -51,7 +51,7 @@ describe.concurrent("Sink", () => {
             Option.some(refinedTo) :
             Option.none(), (error) => error.message)
       )
-      const result = yield* $(pipe(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit))
+      const result = yield* $(Stream.make(1, 2, 3), Stream.run(sink), Effect.exit)
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(void 0))
     }))
 })

--- a/test/Sink/scoping.ts
+++ b/test/Sink/scoping.ts
@@ -29,7 +29,7 @@ describe.concurrent("Sink", () => {
         ),
         Sink.unwrapScoped
       )
-      const [result, state] = yield* $(pipe(Stream.make(1, 2, 3), Stream.run(sink)))
+      const [result, state] = yield* $(Stream.make(1, 2, 3), Stream.run(sink))
       const finalState = yield* $(Ref.get(ref))
       assert.strictEqual(result, 103)
       assert.isFalse(state)
@@ -44,7 +44,7 @@ describe.concurrent("Sink", () => {
         () => Ref.set(ref, true)
       )
       const sink = pipe(resource, Effect.as(Sink.succeed("ok")), Sink.unwrapScoped)
-      const result = yield* $(pipe(Stream.fail("fail"), Stream.run(sink)))
+      const result = yield* $(Stream.fail("fail"), Stream.run(sink))
       const finalState = yield* $(Ref.get(ref))
       assert.strictEqual(result, "ok")
       assert.isTrue(finalState)

--- a/test/Sink/sequencing.ts
+++ b/test/Sink/sequencing.ts
@@ -11,14 +11,14 @@ describe.concurrent("Sink", () => {
   it.effect("flatMap - empty input", () =>
     Effect.gen(function*($) {
       const sink = pipe(Sink.head<number>(), Sink.flatMap(Sink.succeed))
-      const result = yield* $(pipe(Stream.empty, Stream.run(sink)))
+      const result = yield* $(Stream.empty, Stream.run(sink))
       assert.deepStrictEqual(result, Option.none())
     }))
 
   it.effect("flatMap - non-empty input", () =>
     Effect.gen(function*($) {
       const sink = pipe(Sink.head<number>(), Sink.flatMap(Sink.succeed))
-      const result = yield* $(pipe(Stream.make(1, 2, 3), Stream.run(sink)))
+      const result = yield* $(Stream.make(1, 2, 3), Stream.run(sink))
       assert.deepStrictEqual(result, Option.some(1))
     }))
 
@@ -39,7 +39,7 @@ describe.concurrent("Sink", () => {
           )
         )
       )
-      const [option, count] = yield* $(pipe(Stream.fromChunks(...chunks), Stream.run(sink)))
+      const [option, count] = yield* $(Stream.fromChunks(...chunks), Stream.run(sink))
       assert.deepStrictEqual(option, Chunk.head(Chunk.flatten(chunks)))
       assert.strictEqual(
         count + Option.match(option, {

--- a/test/Sink/traversing.ts
+++ b/test/Sink/traversing.ts
@@ -19,15 +19,13 @@ describe.concurrent("Sink", () => {
         }))
       )
       const result = yield* $(
-        pipe(
-          [1, 3, 7, 20],
-          Effect.forEach((n) =>
-            pipe(
-              Stream.range(1, 100),
-              Stream.rechunk(n),
-              Stream.run(sink),
-              Effect.map((option) => Equal.equals(option, Option.some(Option.some(10))))
-            )
+        [1, 3, 7, 20],
+        Effect.forEach((n) =>
+          pipe(
+            Stream.range(1, 100),
+            Stream.rechunk(n),
+            Stream.run(sink),
+            Effect.map((option) => Equal.equals(option, Option.some(Option.some(10))))
           )
         )
       )
@@ -41,12 +39,10 @@ describe.concurrent("Sink", () => {
         Sink.findEffect((chunk) => Effect.succeed(pipe(chunk, Chunk.reduce(0, (x, y) => x + y)) > 10))
       )
       const result = yield* $(
-        pipe(
-          Stream.fromIterable(Chunk.range(1, 8)),
-          Stream.rechunk(2),
-          Stream.run(sink),
-          Effect.map(Option.getOrElse(() => Chunk.empty<number>()))
-        )
+        Stream.fromIterable(Chunk.range(1, 8)),
+        Stream.rechunk(2),
+        Stream.run(sink),
+        Effect.map(Option.getOrElse(() => Chunk.empty<number>()))
       )
       assert.deepStrictEqual(Array.from(result), [5, 6, 7, 8])
     }))
@@ -58,10 +54,8 @@ describe.concurrent("Sink", () => {
         Sink.findEffect((n) => Effect.succeed(n > 0))
       )
       const result = yield* $(
-        pipe(
-          Stream.fromIterable([]),
-          Stream.run(sink)
-        )
+        Stream.fromIterable([]),
+        Stream.run(sink)
       )
       assert.deepStrictEqual(result, Option.none())
     }))
@@ -76,10 +70,8 @@ describe.concurrent("Sink", () => {
         }))
       )
       const result = yield* $(
-        pipe(
-          Stream.fromIterable([1, 2]),
-          Stream.run(sink)
-        )
+        Stream.fromIterable([1, 2]),
+        Stream.run(sink)
       )
       assert.deepStrictEqual(result, Option.none())
     }))
@@ -87,13 +79,11 @@ describe.concurrent("Sink", () => {
   it.effect("forEachWhile - handles leftovers", () =>
     Effect.gen(function*($) {
       const [result, value] = yield* $(
-        pipe(
-          Stream.range(1, 5),
-          Stream.run(pipe(
-            Sink.forEachWhile((n: number) => Effect.succeed(n <= 3)),
-            Sink.collectLeftover
-          ))
-        )
+        Stream.range(1, 5),
+        Stream.run(pipe(
+          Sink.forEachWhile((n: number) => Effect.succeed(n <= 3)),
+          Sink.collectLeftover
+        ))
       )
       assert.isUndefined(result)
       assert.deepStrictEqual(Array.from(value), [4])
@@ -102,11 +92,11 @@ describe.concurrent("Sink", () => {
   it.effect("splitWhere - should split a stream on a predicate and run each part into the sink", () =>
     Effect.gen(function*($) {
       const stream = Stream.make(1, 2, 3, 4, 5, 6, 7, 8)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.transduce(pipe(Sink.collectAll<number>(), Sink.splitWhere((n) => n % 2 === 0))),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1], [2, 3], [4, 5], [6, 7], [8]]
@@ -116,11 +106,11 @@ describe.concurrent("Sink", () => {
   it.effect("splitWhere - should split a stream on a predicate and run each part into the sink, in several chunks", () =>
     Effect.gen(function*($) {
       const stream = Stream.fromChunks(Chunk.make(1, 2, 3, 4), Chunk.make(5, 6, 7, 8))
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.transduce(pipe(Sink.collectAll<number>(), Sink.splitWhere((n) => n % 2 === 0))),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1], [2, 3], [4, 5], [6, 7], [8]]
@@ -130,11 +120,11 @@ describe.concurrent("Sink", () => {
   it.effect("splitWhere - should not yield an empty sink if split on the first element", () =>
     Effect.gen(function*($) {
       const stream = Stream.make(1, 2, 3, 4, 5, 6, 7, 8)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.transduce(pipe(Sink.collectAll<number>(), Sink.splitWhere((n) => n % 2 !== 0))),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1, 2], [3, 4], [5, 6], [7, 8]]

--- a/test/Sink/zipping.ts
+++ b/test/Sink/zipping.ts
@@ -46,25 +46,25 @@ const zipParLaw = <A, B, C, E>(
 describe.concurrent("Sink", () => {
   it.effect("zipParLeft", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.run(pipe(
           Sink.head(),
           Sink.zipLeft(Sink.succeed("hello"), { concurrent: true })
         ))
-      ))
+      )
       assert.deepStrictEqual(result, Option.some(1))
     }))
 
   it.effect("zipParRight", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.run(pipe(
           Sink.head(),
           Sink.zipRight(Sink.succeed("hello"), { concurrent: true })
         ))
-      ))
+      )
       assert.strictEqual(result, "hello")
     }))
 

--- a/test/Stream/async.ts
+++ b/test/Stream/async.ts
@@ -17,7 +17,7 @@ describe.concurrent("Stream", () => {
   it.effect("async", () =>
     Effect.gen(function*($) {
       const array = [1, 2, 3, 4, 5]
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.async<never, never, number>((emit) => {
           array.forEach((n) => {
             emit(Effect.succeed(Chunk.of(n)))
@@ -25,7 +25,7 @@ describe.concurrent("Stream", () => {
         }),
         Stream.take(array.length),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), array)
     }))
 
@@ -33,7 +33,7 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const array = [1, 2, 3, 4, 5]
       const latch = yield* $(Deferred.make<never, void>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.asyncEffect<never, never, number>((emit) => {
           array.forEach((n) => {
             emit(Effect.succeed(Chunk.of(n)))
@@ -46,7 +46,7 @@ describe.concurrent("Stream", () => {
         Stream.take(array.length),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(latch))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), array)
@@ -55,39 +55,39 @@ describe.concurrent("Stream", () => {
   it.effect("asyncEffect - handles errors", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncEffect<never, Cause.RuntimeException, number>((emit) => {
           emit.fromEffect(Effect.fail(error))
           return Effect.unit
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 
   it.effect("asyncEffect - handles defects", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncEffect<never, Cause.RuntimeException, number>(() => {
           throw error
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
   it.effect("asyncEffect - signals the end of the stream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncEffect<never, never, number>((emit) => {
           emit(Effect.fail(Option.none()))
           return Effect.unit
         }),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
@@ -117,8 +117,8 @@ describe.concurrent("Stream", () => {
         return Effect.unit
       }, 5)
       const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(pipe(stream, Stream.run(sink), Effect.fork))
-      yield* $(pipe(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7)))
+      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+      yield* $(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7))
       const result = yield* $(Ref.get(refDone))
       yield* $(Fiber.interrupt(fiber))
       assert.isFalse(result)
@@ -128,7 +128,7 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
       const latch = yield* $(Deferred.make<never, void>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.asyncInterrupt<never, never, void>((emit) => {
           emit.chunk(Chunk.of(void 0))
           return Either.left(Ref.set(ref, true))
@@ -136,7 +136,7 @@ describe.concurrent("Stream", () => {
         Stream.tap(() => Deferred.succeed<never, void>(latch, void 0)),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(latch))
       yield* $(Fiber.interrupt(fiber))
       const result = yield* $(Ref.get(ref))
@@ -146,49 +146,49 @@ describe.concurrent("Stream", () => {
   it.effect("asyncInterrupt - right", () =>
     Effect.gen(function*($) {
       const chunk = Chunk.range(1, 5)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncInterrupt<never, never, number>(() => Either.right(Stream.fromChunk(chunk))),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), Array.from(chunk))
     }))
 
   it.effect("asyncInterrupt - signals the end of the stream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncInterrupt<never, never, number>((emit) => {
           emit.end()
           return Either.left(Effect.unit)
         }),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
   it.effect("asyncInterrupt - handles errors", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncInterrupt<never, Cause.RuntimeException, number>((emit) => {
           emit.fromEffect(Effect.fail(error))
           return Either.left(Effect.unit)
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 
   it.effect("asyncInterrupt - handles defects", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncInterrupt<never, Cause.RuntimeException, number>(() => {
           throw error
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
@@ -218,39 +218,39 @@ describe.concurrent("Stream", () => {
         return Either.left(Effect.unit)
       }, 5)
       const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(pipe(stream, Stream.run(sink), Effect.fork))
-      yield* $(pipe(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7)))
+      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+      yield* $(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7))
       const result = yield* $(Ref.get(refDone))
-      yield* $(pipe(Fiber.interrupt(fiber), Effect.exit))
+      yield* $(Fiber.interrupt(fiber), Effect.exit)
       assert.isFalse(result)
     }))
 
   it.effect("asyncOption - signals the end of the stream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncOption<never, never, number>((emit) => {
           emit(Effect.fail(Option.none()))
           return Option.none()
         }),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
   it.effect("asyncOption - some", () =>
     Effect.gen(function*($) {
       const chunk = Chunk.range(1, 5)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncOption<never, never, number>(() => Option.some(Stream.fromChunk(chunk))),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), Array.from(chunk))
     }))
 
   it.effect("asyncOption - none", () =>
     Effect.gen(function*($) {
       const array = [1, 2, 3, 4, 5]
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncOption<never, never, number>((emit) => {
           array.forEach((n) => {
             emit(Effect.succeed(Chunk.of(n)))
@@ -259,34 +259,34 @@ describe.concurrent("Stream", () => {
         }),
         Stream.take(array.length),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), array)
     }))
 
   it.effect("asyncOption - handles errors", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncOption<never, Cause.RuntimeException, number>((emit) => {
           emit.fromEffect(Effect.fail(error))
           return Option.none()
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 
   it.effect("asyncOption - handles defects", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncOption<never, Cause.RuntimeException, number>(() => {
           throw error
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
@@ -316,10 +316,10 @@ describe.concurrent("Stream", () => {
         return Option.none()
       }, 5)
       const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(pipe(stream, Stream.run(sink), Effect.fork))
-      yield* $(pipe(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7)))
+      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+      yield* $(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7))
       const result = yield* $(Ref.get(refDone))
-      yield* $(pipe(Fiber.interrupt(fiber), Effect.exit))
+      yield* $(Fiber.interrupt(fiber), Effect.exit)
       assert.isFalse(result)
     }))
 
@@ -327,7 +327,7 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const array = [1, 2, 3, 4, 5]
       const latch = yield* $(Deferred.make<never, void>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.asyncScoped<never, never, number>((cb) => {
           array.forEach((n) => {
             cb(Effect.succeed(Chunk.of(n)))
@@ -340,7 +340,7 @@ describe.concurrent("Stream", () => {
         Stream.take(array.length),
         Stream.run(Sink.collectAll()),
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(latch))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), array)
@@ -348,40 +348,40 @@ describe.concurrent("Stream", () => {
 
   it.effect("asyncScoped - signals the end of the stream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncScoped<never, never, number>((cb) => {
           cb(Effect.fail(Option.none()))
           return Effect.unit
         }),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
   it.effect("asyncScoped - handles errors", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncScoped<never, Cause.RuntimeException, number>((cb) => {
           cb(Effect.fail(Option.some(error)))
           return Effect.unit
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 
   it.effect("asyncScoped - handles defects", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.asyncScoped<never, Cause.RuntimeException, number>(() => {
           throw error
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
@@ -411,10 +411,10 @@ describe.concurrent("Stream", () => {
         return Effect.unit
       }, 5)
       const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(pipe(stream, Stream.run(sink), Effect.fork))
-      yield* $(pipe(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7)))
+      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+      yield* $(Ref.get(refCount), Effect.repeatWhile((n) => n !== 7))
       const result = yield* $(Ref.get(refDone))
-      yield* $(pipe(Fiber.interrupt(fiber), Effect.exit))
+      yield* $(Fiber.interrupt(fiber), Effect.exit)
       assert.isFalse(result)
     }))
 })

--- a/test/Stream/broadcasting.ts
+++ b/test/Stream/broadcasting.ts
@@ -13,17 +13,15 @@ describe.concurrent("Stream", () => {
   it.effect("broadcast - values", () =>
     Effect.gen(function*($) {
       const { result1, result2 } = yield* $(
-        pipe(
-          Stream.range(0, 5),
-          Stream.broadcast(2, 12),
-          Effect.flatMap((streams) =>
-            Effect.all({
-              result1: Stream.runCollect(streams[0]),
-              result2: Stream.runCollect(streams[1])
-            })
-          ),
-          Effect.scoped
-        )
+        Stream.range(0, 5),
+        Stream.broadcast(2, 12),
+        Effect.flatMap((streams) =>
+          Effect.all({
+            result1: Stream.runCollect(streams[0]),
+            result2: Stream.runCollect(streams[1])
+          })
+        ),
+        Effect.scoped
       )
       const expected = [0, 1, 2, 3, 4]
       assert.deepStrictEqual(Array.from(result1), expected)
@@ -33,18 +31,16 @@ describe.concurrent("Stream", () => {
   it.effect("broadcast - errors", () =>
     Effect.gen(function*($) {
       const { result1, result2 } = yield* $(
-        pipe(
-          Stream.range(0, 1),
-          Stream.concat(Stream.fail("boom")),
-          Stream.broadcast(2, 12),
-          Effect.flatMap((streams) =>
-            Effect.all({
-              result1: pipe(streams[0], Stream.runCollect, Effect.either),
-              result2: pipe(streams[1], Stream.runCollect, Effect.either)
-            })
-          ),
-          Effect.scoped
-        )
+        Stream.range(0, 1),
+        Stream.concat(Stream.fail("boom")),
+        Stream.broadcast(2, 12),
+        Effect.flatMap((streams) =>
+          Effect.all({
+            result1: pipe(streams[0], Stream.runCollect, Effect.either),
+            result2: pipe(streams[1], Stream.runCollect, Effect.either)
+          })
+        ),
+        Effect.scoped
       )
       assert.deepStrictEqual(result1, Either.left("boom"))
       assert.deepStrictEqual(result2, Either.left("boom"))
@@ -53,40 +49,36 @@ describe.concurrent("Stream", () => {
   it.effect("broadcast - backpressure", () =>
     Effect.gen(function*($) {
       const { result1, result2 } = yield* $(
-        pipe(
-          Stream.range(0, 5),
-          Stream.flatMap(Stream.succeed),
-          Stream.broadcast(2, 2),
-          Effect.flatMap((streams) =>
-            Effect.gen(function*($) {
-              const ref = yield* $(Ref.make(Chunk.empty<number>()))
-              const latch = yield* $(Deferred.make<never, void>())
-              const fiber = yield* $(
+        Stream.range(0, 5),
+        Stream.flatMap(Stream.succeed),
+        Stream.broadcast(2, 2),
+        Effect.flatMap((streams) =>
+          Effect.gen(function*($) {
+            const ref = yield* $(Ref.make(Chunk.empty<number>()))
+            const latch = yield* $(Deferred.make<never, void>())
+            const fiber = yield* $(
+              streams[0],
+              Stream.tap((n) =>
                 pipe(
-                  streams[0],
-                  Stream.tap((n) =>
-                    pipe(
-                      Ref.update(ref, Chunk.append(n)),
-                      Effect.zipRight(pipe(
-                        Deferred.succeed<never, void>(latch, void 0),
-                        Effect.when(() => n === 1)
-                      ))
-                    )
-                  ),
-                  Stream.runDrain,
-                  Effect.fork
+                  Ref.update(ref, Chunk.append(n)),
+                  Effect.zipRight(pipe(
+                    Deferred.succeed<never, void>(latch, void 0),
+                    Effect.when(() => n === 1)
+                  ))
                 )
-              )
-              yield* $(Deferred.await(latch))
-              const result1 = yield* $(Ref.get(ref))
-              yield* $(Stream.runDrain(streams[1]))
-              yield* $(Fiber.await(fiber))
-              const result2 = yield* $(Ref.get(ref))
-              return { result1, result2 }
-            })
-          ),
-          Effect.scoped
-        )
+              ),
+              Stream.runDrain,
+              Effect.fork
+            )
+            yield* $(Deferred.await(latch))
+            const result1 = yield* $(Ref.get(ref))
+            yield* $(Stream.runDrain(streams[1]))
+            yield* $(Fiber.await(fiber))
+            const result2 = yield* $(Ref.get(ref))
+            return { result1, result2 }
+          })
+        ),
+        Effect.scoped
       )
       assert.deepStrictEqual(Array.from(result1), [0, 1])
       assert.deepStrictEqual(Array.from(result2), [0, 1, 2, 3, 4])
@@ -95,19 +87,17 @@ describe.concurrent("Stream", () => {
   it.effect("broadcast - unsubscribe", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.range(0, 5),
-          Stream.broadcast(2, 2),
-          Effect.flatMap((streams) =>
-            pipe(
-              Stream.toPull(streams[0]),
-              Effect.ignore,
-              Effect.scoped,
-              Effect.zipRight(Stream.runCollect(streams[1]))
-            )
-          ),
-          Effect.scoped
-        )
+        Stream.range(0, 5),
+        Stream.broadcast(2, 2),
+        Effect.flatMap((streams) =>
+          pipe(
+            Stream.toPull(streams[0]),
+            Effect.ignore,
+            Effect.scoped,
+            Effect.zipRight(Stream.runCollect(streams[1]))
+          )
+        ),
+        Effect.scoped
       )
       assert.deepStrictEqual(Array.from(result), [0, 1, 2, 3, 4])
     }))

--- a/test/Stream/changing.ts
+++ b/test/Stream/changing.ts
@@ -1,5 +1,4 @@
 import * as Chunk from "@effect/data/Chunk"
-import { pipe } from "@effect/data/Function"
 import * as Effect from "@effect/io/Effect"
 import * as Stream from "@effect/stream/Stream"
 import * as it from "@effect/stream/test/utils/extend"
@@ -9,34 +8,34 @@ describe.concurrent("Stream", () => {
   it.effect("changes", () =>
     Effect.gen(function*($) {
       const stream = Stream.range(0, 20)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.changes,
         Stream.runCollect
-      ))
-      const expected = yield* $(pipe(
+      )
+      const expected = yield* $(
         stream,
         Stream.runCollect,
         Effect.map(Chunk.reduce(Chunk.empty<number>(), (acc, n) =>
           acc.length === 0 || Chunk.unsafeGet(acc, 0) !== n ? Chunk.append(acc, n) : acc))
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), Array.from(expected))
     }))
 
   it.effect("changesWithEffect", () =>
     Effect.gen(function*($) {
       const stream = Stream.range(0, 20)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.changesWithEffect((left, right) => Effect.succeed(left === right)),
         Stream.runCollect
-      ))
-      const expected = yield* $(pipe(
+      )
+      const expected = yield* $(
         stream,
         Stream.runCollect,
         Effect.map(Chunk.reduce(Chunk.empty<number>(), (acc, n) =>
           acc.length === 0 || Chunk.unsafeGet(acc, 0) !== n ? Chunk.append(acc, n) : acc))
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), Array.from(expected))
     }))
 })

--- a/test/Stream/collecting.ts
+++ b/test/Stream/collecting.ts
@@ -1,6 +1,6 @@
 import * as Chunk from "@effect/data/Chunk"
 import * as Either from "@effect/data/Either"
-import { identity, pipe } from "@effect/data/Function"
+import { identity } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import * as Effect from "@effect/io/Effect"
 import * as Stream from "@effect/stream/Stream"
@@ -10,7 +10,7 @@ import { assert, describe } from "vitest"
 describe.concurrent("Stream", () => {
   it.effect("collect", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Either.left(1), Either.right(2), Either.left(3)),
         Stream.filterMap((either) =>
           Either.isRight(either) ?
@@ -18,13 +18,13 @@ describe.concurrent("Stream", () => {
             Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [2])
     }))
 
   it.effect("collectEffect - simple example", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Either.left(1), Either.right(2), Either.left(3)),
         Stream.filterMapEffect((either) =>
           Either.isRight(either) ?
@@ -32,7 +32,7 @@ describe.concurrent("Stream", () => {
             Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [4])
     }))
 
@@ -42,7 +42,7 @@ describe.concurrent("Stream", () => {
         Chunk.make(Either.left(1), Either.right(2)),
         Chunk.make(Either.right(3), Either.left(4))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(...chunks),
         Stream.filterMapEffect((either) =>
           Either.isRight(either) ?
@@ -50,24 +50,24 @@ describe.concurrent("Stream", () => {
             Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [20, 30])
     }))
 
   it.effect("collectEffect - handles failures", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Either.left(1), Either.right(2), Either.left(3)),
         Stream.filterMapEffect(() => Option.some(Effect.fail("Ouch"))),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
   it.effect("collectEffect - laziness on chunks", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.filterMapEffect((n) =>
           n === 3 ?
@@ -76,7 +76,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result),
         [Either.right(1), Either.right(2), Either.left("boom")]
@@ -85,29 +85,29 @@ describe.concurrent("Stream", () => {
 
   it.effect("collectWhile - simple example", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Option.some(1), Option.some(2), Option.none(), Option.some(4)),
         Stream.filterMapWhile(identity),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2])
     }))
 
   it.effect("collectWhile - short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Option.some(1)),
         Stream.concat(Stream.fail("Ouch")),
         Stream.filterMapWhile((option) => Option.isNone(option) ? Option.some(1) : Option.none()),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.right(void 0))
     }))
 
   it.effect("collectWhileEffect - simple example", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Option.some(1), Option.some(2), Option.none(), Option.some(4)),
         Stream.filterMapWhileEffect((option) =>
           Option.isSome(option) ?
@@ -115,13 +115,13 @@ describe.concurrent("Stream", () => {
             Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [2, 4])
     }))
 
   it.effect("collectWhileEffect - short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Option.some(1)),
         Stream.concat(Stream.fail("Ouch")),
         Stream.filterMapWhileEffect((option) =>
@@ -131,24 +131,24 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.right(void 0))
     }))
 
   it.effect("collectWhileEffect - fails", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(Option.some(1), Option.some(2), Option.none(), Option.some(3)),
         Stream.filterMapWhileEffect(() => Option.some(Effect.fail("Ouch"))),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
   it.effect("collectWhileEffect - laziness on chunks", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.filterMapWhileEffect((n) =>
           n === 3 ?
@@ -157,7 +157,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result),
         [Either.right(1), Either.right(2), Either.left("boom")]

--- a/test/Stream/concatenation.ts
+++ b/test/Stream/concatenation.ts
@@ -32,11 +32,11 @@ describe.concurrent("Stream", () => {
   it.effect("concat - finalizer ordering", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(Chunk.empty<string>()))
-      yield* $(pipe(
+      yield* $(
         Stream.finalizer(Ref.update(ref, Chunk.append("Second"))),
         Stream.concat(Stream.finalizer(Ref.update(ref, Chunk.append("First")))),
         Stream.runDrain
-      ))
+      )
       const result = yield* $(Ref.get(ref))
       assert.deepStrictEqual(Array.from(result), ["Second", "First"])
     }))

--- a/test/Stream/conditionals.ts
+++ b/test/Stream/conditionals.ts
@@ -23,31 +23,31 @@ describe.concurrent("Stream", () => {
 
   it.effect("when - returns an empty stream if the condition is not satisfied", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4, 5),
         Stream.when(constFalse),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
   it.effect("when - dies if the condition throws an exception", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.when(() => {
           throw error
         }),
         Stream.runDrain,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
   it.effect("whenCase - returns the resulting stream if the given partial function is defined for the given value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.whenCase(
           () => Option.some(1),
           (option) =>
@@ -56,13 +56,13 @@ describe.concurrent("Stream", () => {
               Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
   it.effect("whenCase - returns an empty stream if the given partial function is not defined for the given value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.whenCase(
           () => Option.none(),
           (option) =>
@@ -71,14 +71,14 @@ describe.concurrent("Stream", () => {
               Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
   it.effect("whenCase - dies if evaluating the given value throws an exception", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.whenCase(
           () => {
             throw error
@@ -87,14 +87,14 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runDrain,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
   it.effect("whenCase - dies if the partial function throws an exception", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.whenCase(
           constVoid,
           (): Option.Option<Stream.Stream<never, never, void>> => {
@@ -103,13 +103,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runDrain,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
   it.effect("whenCaseEffect - returns the resulting stream if the given partial function is defined for the given effectful value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.succeed(Option.some(1)),
         Stream.whenCaseEffect(
           (option) =>
@@ -118,13 +118,13 @@ describe.concurrent("Stream", () => {
               Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
   it.effect("whenCaseEffect - returns an empty stream if the given partial function is not defined for the given effectful value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.succeed<Option.Option<number>>(Option.none()),
         Stream.whenCaseEffect(
           (option) =>
@@ -133,65 +133,65 @@ describe.concurrent("Stream", () => {
               Option.none()
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
   it.effect("whenCaseEffect - fails if the effectful value is a failure", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.fail(error),
         Stream.whenCaseEffect(() => Option.some(Stream.empty)),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 
   it.effect("whenCaseEffect - dies if the given partial function throws an exception", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.unit,
         Stream.whenCaseEffect((): Option.Option<Stream.Stream<never, never, void>> => {
           throw error
         }),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die(error))
     }))
 
   it.effect("whenEffect - returns the stream if the effectful condition is satisfied", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4, 5),
         Stream.whenEffect(Effect.succeed(true)),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4, 5])
     }))
 
   it.effect("whenEffect - returns an empty stream if the effectful condition is not satisfied", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4, 5),
         Stream.whenEffect(Effect.succeed(false)),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
   it.effect("whenEffect - fails if the effectful condition fails", () =>
     Effect.gen(function*($) {
       const error = Cause.RuntimeException("boom")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.whenEffect(Effect.fail(error)),
         Stream.runDrain,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(error))
     }))
 })

--- a/test/Stream/conversions.ts
+++ b/test/Stream/conversions.ts
@@ -17,7 +17,7 @@ describe.concurrent("Stream", () => {
         Stream.fromChunk(chunk),
         Stream.flatMap(Stream.succeed)
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.toQueue({ capacity: 1_000 }),
         Effect.flatMap((queue) =>
@@ -28,7 +28,7 @@ describe.concurrent("Stream", () => {
           )
         ),
         Effect.scoped
-      ))
+      )
       const expected = pipe(
         chunk,
         Chunk.map(Take.of),
@@ -44,7 +44,7 @@ describe.concurrent("Stream", () => {
         Stream.fromChunk(chunk),
         Stream.flatMap(Stream.succeed)
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.toQueue(stream, { strategy: "unbounded" }),
         Effect.flatMap((queue) =>
           pipe(
@@ -54,7 +54,7 @@ describe.concurrent("Stream", () => {
           )
         ),
         Effect.scoped
-      ))
+      )
       const expected = pipe(
         chunk,
         Chunk.map(Take.of),
@@ -65,12 +65,12 @@ describe.concurrent("Stream", () => {
 
   it.effect("toQueueOfElements - propagates defects", () =>
     Effect.gen(function*($) {
-      const queue = yield* $(pipe(
+      const queue = yield* $(
         Stream.dieMessage("die"),
         Stream.toQueueOfElements({ capacity: 1 }),
         Effect.flatMap(Queue.take),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(queue), Exit.die(Cause.RuntimeException("die")))
     }))
 })

--- a/test/Stream/distributing.ts
+++ b/test/Stream/distributing.ts
@@ -10,7 +10,7 @@ import { assert, describe } from "vitest"
 describe.concurrent("Stream", () => {
   it.effect("distributedWithDynamic - ensures no race between subscription and stream end", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.empty,
         Stream.distributedWithDynamic({
           maximumLag: 1,
@@ -45,7 +45,7 @@ describe.concurrent("Stream", () => {
           )
         }),
         Effect.scoped
-      ))
+      )
       assert.isUndefined(result)
     }))
 })

--- a/test/Stream/dropping.ts
+++ b/test/Stream/dropping.ts
@@ -20,13 +20,13 @@ describe.concurrent("Stream", () => {
 
   it.effect("drop - does not swallow errors", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fail("Ouch"),
         Stream.concat(Stream.make(1)),
         Stream.drop(1),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -43,13 +43,13 @@ describe.concurrent("Stream", () => {
 
   it.effect("dropRight - does not swallow errors", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.concat(Stream.fail("Ouch")),
         Stream.dropRight(1),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -80,14 +80,14 @@ describe.concurrent("Stream", () => {
 
   it.effect("dropWhile - short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.concat(Stream.fail("Ouch")),
         Stream.take(1),
         Stream.dropWhile(constTrue),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.right(void 0))
     }))
 })

--- a/test/Stream/environment.ts
+++ b/test/Stream/environment.ts
@@ -20,18 +20,18 @@ describe.concurrent("Stream", () => {
         Context.empty(),
         Context.add(StringService, { string: "test" })
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.context<StringService>(),
         Stream.map(Context.get(StringService)),
         Stream.provideContext(context),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [{ string: "test" }])
     }))
 
   it.effect("contextWith", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         StringService,
         Stream.provideContext(
           pipe(
@@ -41,13 +41,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runHead,
         Effect.some
-      ))
+      )
       assert.deepStrictEqual(result, { string: "test" })
     }))
 
   it.effect("contextWithEffect - success", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.contextWithEffect((context: Context.Context<StringService>) =>
           Effect.succeed(pipe(context, Context.get(StringService)))
         ),
@@ -59,13 +59,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runHead,
         Effect.some
-      ))
+      )
       assert.deepStrictEqual(result, { string: "test" })
     }))
 
   it.effect("contextWithEffect - fails", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.contextWithEffect((_: Context.Context<StringService>) => Effect.fail("boom")),
         Stream.provideContext(
           pipe(
@@ -75,13 +75,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runHead,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("boom"))
     }))
 
   it.effect("contextWithStream - success", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.contextWithStream((context: Context.Context<StringService>) =>
           Stream.succeed(pipe(context, Context.get(StringService)))
         ),
@@ -93,13 +93,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runHead,
         Effect.some
-      ))
+      )
       assert.deepStrictEqual(result, { string: "test" })
     }))
 
   it.effect("contextWithStream - fails", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.contextWithStream((_: Context.Context<StringService>) => Stream.fail("boom")),
         Stream.provideContext(
           pipe(
@@ -109,7 +109,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runHead,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("boom"))
     }))
 
@@ -117,12 +117,12 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const stream = StringService
       const layer = Layer.succeed(StringService, { string: "test" })
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.provideLayer(layer),
         Stream.map((s) => s.string),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["test"])
     }))
 
@@ -130,42 +130,42 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const stream = StringService
       const service = Stream.succeed<StringService>({ string: "test" })
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.provideServiceStream(StringService, service),
         Stream.map((s) => s.string),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["test"])
     }))
 
   it.effect("serviceWith", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.map(StringService, (service) => service.string),
         Stream.provideLayer(Layer.succeed(StringService, { string: "test" })),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["test"])
     }))
 
   it.effect("serviceWithEffect", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.mapEffect(StringService, (service) => Effect.succeed(service.string)),
         Stream.provideLayer(Layer.succeed(StringService, { string: "test" })),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["test"])
     }))
 
   it.effect("serviceWithStream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.flatMap(StringService, (service) => Stream.succeed(service.string)),
         Stream.provideLayer(Layer.succeed(StringService, { string: "test" })),
         Stream.runCollect
-      ))
+      )
       console.log("serviceWithStream")
       assert.deepStrictEqual(Array.from(result), ["test"])
     }))

--- a/test/Stream/filtering.ts
+++ b/test/Stream/filtering.ts
@@ -31,7 +31,7 @@ describe.concurrent("Stream", () => {
 
   it.effect("filterEffect - laziness on chunks", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.filterEffect((n) =>
           n === 3 ?
@@ -40,7 +40,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result),
         [Either.right(1), Either.right(2), Either.left("boom")]

--- a/test/Stream/finding.ts
+++ b/test/Stream/finding.ts
@@ -51,7 +51,7 @@ describe.concurrent("Stream", () => {
 
   it.effect("findEffect - throws correct error", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.findEffect((n) =>
           n === 3 ?
@@ -60,7 +60,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result),
         [Either.left("boom")]

--- a/test/Stream/getters.ts
+++ b/test/Stream/getters.ts
@@ -1,5 +1,4 @@
 import * as Either from "@effect/data/Either"
-import { pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import * as Effect from "@effect/io/Effect"
 import * as Stream from "@effect/stream/Stream"
@@ -9,36 +8,36 @@ import { assert, describe } from "vitest"
 describe.concurrent("Stream", () => {
   it.effect("some", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.succeed(Option.some(1)),
         Stream.concat(Stream.succeed(Option.none())),
         Stream.some,
         Stream.runCollect,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left(Option.none()))
     }))
 
   it.effect("some", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.succeed(Option.some(1)),
         Stream.concat(Stream.succeed(Option.none())),
         Stream.someOrElse(() => -1),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, -1])
     }))
 
   it.effect("someOrFail", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.succeed(Option.some(1)),
         Stream.concat(Stream.succeed(Option.none())),
         Stream.someOrFail(() => -1),
         Stream.runCollect,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left(-1))
     }))
 })

--- a/test/Stream/halting.ts
+++ b/test/Stream/halting.ts
@@ -1,7 +1,6 @@
 import * as Chunk from "@effect/data/Chunk"
 import * as Duration from "@effect/data/Duration"
 import * as Either from "@effect/data/Either"
-import { pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import * as Deferred from "@effect/io/Deferred"
 import * as Effect from "@effect/io/Effect"
@@ -21,14 +20,14 @@ describe.concurrent("Stream", () => {
       const ref = yield* $(Ref.make(false))
       const latch = yield* $(Deferred.make<never, void>())
       const halt = yield* $(Deferred.make<never, void>())
-      yield* $(pipe(
+      yield* $(
         Deferred.await(latch),
         Effect.onInterrupt(() => Ref.set(ref, true)),
         Stream.fromEffect,
         Stream.haltWhen(Deferred.await(halt)),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.succeed<never, void>(halt, void 0))
       yield* $(Deferred.succeed<never, void>(latch, void 0))
       const result = yield* $(Ref.get(ref))
@@ -39,13 +38,13 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const halt = yield* $(Deferred.make<string, void>())
       yield* $(Deferred.fail(halt, "fail"))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(0),
         Stream.forever,
         Stream.haltWhen(Deferred.await(halt)),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("fail"))
     }))
 
@@ -54,14 +53,14 @@ describe.concurrent("Stream", () => {
       const ref = yield* $(Ref.make(false))
       const latch = yield* $(Deferred.make<never, void>())
       const halt = yield* $(Deferred.make<never, void>())
-      yield* $(pipe(
+      yield* $(
         Deferred.await(latch),
         Effect.onInterrupt(() => Ref.set(ref, true)),
         Stream.fromEffect,
         Stream.haltWhenDeferred(halt),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.succeed<never, void>(halt, void 0))
       yield* $(Deferred.succeed<never, void>(latch, void 0))
       const result = yield* $(Ref.get(ref))
@@ -72,12 +71,12 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const halt = yield* $(Deferred.make<string, void>())
       yield* $(Deferred.fail(halt, "fail"))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.haltWhenDeferred(halt),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("fail"))
     }))
 
@@ -89,7 +88,7 @@ describe.concurrent("Stream", () => {
         Chunk.of(3),
         Chunk.of(4)
       ]))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(coordination.queue),
         Stream.filterMapWhile(Exit.match({
           onFailure: Option.none,
@@ -99,22 +98,22 @@ describe.concurrent("Stream", () => {
         Stream.tap(() => coordination.proceed),
         Stream.runCollect,
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.seconds(3))),
         Effect.zipRight(coordination.awaitNext)
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.seconds(3))),
         Effect.zipRight(coordination.awaitNext)
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.seconds(3))),
         Effect.zipRight(coordination.awaitNext)
-      ))
+      )
       yield* $(coordination.offer)
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(
@@ -126,14 +125,14 @@ describe.concurrent("Stream", () => {
   it.effect("haltAfter - will process first chunk", () =>
     Effect.gen(function*($) {
       const queue = yield* $(Queue.unbounded<number>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(queue),
         Stream.haltAfter(Duration.seconds(5)),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(6)))
-      yield* $(pipe(Queue.offer(queue, 1)))
+      yield* $(Queue.offer(queue, 1))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [1])
     }))

--- a/test/Stream/interleaving.ts
+++ b/test/Stream/interleaving.ts
@@ -11,11 +11,11 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const stream1 = Stream.make(2, 3)
       const stream2 = Stream.make(5, 6, 7)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream1,
         Stream.interleave(stream2),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [2, 5, 3, 6, 7])
     }))
 
@@ -61,11 +61,11 @@ describe.concurrent("Stream", () => {
       const boolStream = Stream.make(true, true, false, true, false)
       const stream1 = Stream.make(1, 2, 3, 4, 5)
       const stream2 = Stream.make(4, 5, 6, 7, 8)
-      const interleavedStream = yield* $(pipe(
+      const interleavedStream = yield* $(
         stream1,
         Stream.interleaveWith(stream2, boolStream),
         Stream.runCollect
-      ))
+      )
       const bools = yield* $(Stream.runCollect(boolStream))
       const numbers1 = yield* $(Stream.runCollect(stream1))
       const numbers2 = yield* $(Stream.runCollect(stream2))

--- a/test/Stream/interrupting.ts
+++ b/test/Stream/interrupting.ts
@@ -23,8 +23,8 @@ describe.concurrent("Stream", () => {
       const queue2 = yield* $(Queue.unbounded<Chunk.Chunk<number>>())
       yield* $(Queue.offer(queue1, Chunk.of(1)))
       yield* $(Queue.offer(queue2, Chunk.of(2)))
-      yield* $(pipe(Queue.offer(queue1, Chunk.of(3)), Effect.fork))
-      yield* $(pipe(Queue.offer(queue2, Chunk.of(4)), Effect.fork))
+      yield* $(Queue.offer(queue1, Chunk.of(3)), Effect.fork)
+      yield* $(Queue.offer(queue2, Chunk.of(4)), Effect.fork)
       const stream1 = Stream.fromChunkQueue(queue1)
       const stream2 = Stream.fromChunkQueue(queue2)
       const stream = pipe(
@@ -43,7 +43,7 @@ describe.concurrent("Stream", () => {
       const latch = yield* $(Deferred.make<never, void>())
       const halt = yield* $(Deferred.make<never, void>())
       const started = yield* $(Deferred.make<never, void>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromEffect(pipe(
           Deferred.succeed<never, void>(started, void 0),
           Effect.zipRight(Deferred.await(latch)),
@@ -52,11 +52,11 @@ describe.concurrent("Stream", () => {
         Stream.interruptWhen(Deferred.await(halt)),
         Stream.runDrain,
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         Deferred.await(started),
         Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
-      ))
+      )
       yield* $(Fiber.await(fiber))
       const result = yield* $(Ref.get(ref))
       assert.isTrue(result)
@@ -66,12 +66,12 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const halt = yield* $(Deferred.make<string, never>())
       yield* $(Deferred.fail(halt, "fail"))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.never,
         Stream.interruptWhen(Deferred.await(halt)),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("fail"))
     }))
 
@@ -81,7 +81,7 @@ describe.concurrent("Stream", () => {
       const latch = yield* $(Deferred.make<never, void>())
       const halt = yield* $(Deferred.make<never, void>())
       const started = yield* $(Deferred.make<never, void>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromEffect(pipe(
           Deferred.succeed<never, void>(started, void 0),
           Effect.zipRight(Deferred.await(latch)),
@@ -90,11 +90,11 @@ describe.concurrent("Stream", () => {
         Stream.interruptWhenDeferred(halt),
         Stream.runDrain,
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         Deferred.await(started),
         Effect.zipRight(Deferred.succeed<never, void>(halt, void 0))
-      ))
+      )
       yield* $(Fiber.await(fiber))
       const result = yield* $(Ref.get(ref))
       assert.isTrue(result)
@@ -104,12 +104,12 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const halt = yield* $(Deferred.make<string, never>())
       yield* $(Deferred.fail(halt, "fail"))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.never,
         Stream.interruptWhenDeferred(halt),
         Stream.runDrain,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("fail"))
     }))
 
@@ -121,7 +121,7 @@ describe.concurrent("Stream", () => {
         Chunk.of(3),
         Chunk.of(4)
       ]))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(coordination.queue),
         Stream.filterMapWhile(Exit.match({
           onFailure: Option.none,
@@ -131,17 +131,17 @@ describe.concurrent("Stream", () => {
         Stream.tap(() => coordination.proceed),
         Stream.runCollect,
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.seconds(3))),
         Effect.zipRight(coordination.awaitNext)
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.seconds(3))),
         Effect.zipRight(coordination.awaitNext)
-      ))
+      )
       yield* $(coordination.offer)
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(
@@ -153,14 +153,14 @@ describe.concurrent("Stream", () => {
   it.effect("interruptAfter - will process first chunk", () =>
     Effect.gen(function*($) {
       const queue = yield* $(Queue.unbounded<number>())
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(queue),
         Stream.interruptAfter(Duration.seconds(5)),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(6)))
-      yield* $(pipe(Queue.offer(queue, 1)))
+      yield* $(Queue.offer(queue, 1))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [])
     }))

--- a/test/Stream/interspersing.ts
+++ b/test/Stream/interspersing.ts
@@ -1,5 +1,4 @@
 import * as Chunk from "@effect/data/Chunk"
-import { pipe } from "@effect/data/Function"
 import * as Effect from "@effect/io/Effect"
 import * as Stream from "@effect/stream/Stream"
 import * as it from "@effect/stream/test/utils/extend"
@@ -8,69 +7,69 @@ import { assert, describe } from "vitest"
 describe.concurrent("Stream", () => {
   it.effect("intersperse - several values", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.map(String),
         Stream.intersperse("."),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["1", ".", "2", ".", "3", ".", "4"])
     }))
 
   it.effect("intersperseAffixes - several values", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.map(String),
         Stream.intersperseAffixes({ start: "[", middle: ".", end: "]" }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["[", "1", ".", "2", ".", "3", ".", "4", "]"])
     }))
 
   it.effect("intersperse - single value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.map(String),
         Stream.intersperse("."),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["1"])
     }))
 
   it.effect("intersperseAffixes - single value", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.map(String),
         Stream.intersperseAffixes({ start: "[", middle: ".", end: "]" }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["[", "1", "]"])
     }))
 
   it.effect("intersperse - several from repeat effect (ZIO #3729)", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.repeatEffect(Effect.succeed(42)),
         Stream.map(String),
         Stream.take(4),
         Stream.intersperse("."),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["42", ".", "42", ".", "42", ".", "42"])
     }))
 
   it.effect("intersperse - several from repeat effect chunk single element (ZIO #3729)", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.repeatEffectChunk(Effect.succeed(Chunk.of(42))),
         Stream.map(String),
         Stream.intersperse("."),
         Stream.take(4),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["42", ".", "42", "."])
     }))
 })

--- a/test/Stream/merging.ts
+++ b/test/Stream/merging.ts
@@ -21,20 +21,20 @@ describe.concurrent("Stream", () => {
         Stream.make(5, 6, 7, 8),
         () => TestServices.provideLive(Effect.sleep(Duration.millis(10)))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.merge(stream1, stream2),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual([...result], [1, 2, 3, 4, 5, 6, 7, 8])
     }))
 
   it.effect("mergeAll - short circuiting", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.mergeAll([Stream.never, Stream.make(1)], { concurrency: 2 }),
         Stream.take(1),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
@@ -44,15 +44,15 @@ describe.concurrent("Stream", () => {
       const queue2 = yield* $(Queue.unbounded<number>())
       const stream1 = Stream.fromQueue(queue1)
       const stream2 = Stream.fromQueue(queue2)
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         stream1,
         Stream.merge(stream2, { haltStrategy: "left" }),
         Stream.runCollect,
         Effect.fork
-      ))
-      yield* $(pipe(Queue.offer(queue1, 1), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
-      yield* $(pipe(Queue.offer(queue1, 2), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
-      yield* $(pipe(Queue.shutdown(queue1), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
+      )
+      yield* $(Queue.offer(queue1, 1), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
+      yield* $(Queue.offer(queue1, 2), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
+      yield* $(Queue.shutdown(queue1), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
       yield* $(Queue.offer(queue2, 3))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [1, 2])
@@ -62,11 +62,11 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const stream1 = Stream.make(1, 2, 3)
       const stream2 = Stream.fromEffect(pipe(Effect.sleep(Duration.seconds(5)), Effect.as(4)))
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream1,
         Stream.merge(stream2, { haltStrategy: "left" }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
@@ -76,15 +76,15 @@ describe.concurrent("Stream", () => {
       const queue2 = yield* $(Queue.unbounded<number>())
       const stream1 = Stream.fromQueue(queue1)
       const stream2 = Stream.fromQueue(queue2)
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         stream1,
         Stream.merge(stream2, { haltStrategy: "right" }),
         Stream.runCollect,
         Effect.fork
-      ))
-      yield* $(pipe(Queue.offer(queue2, 1), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
-      yield* $(pipe(Queue.offer(queue2, 2), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
-      yield* $(pipe(Queue.shutdown(queue2), Effect.zipRight(TestClock.adjust(Duration.seconds(1)))))
+      )
+      yield* $(Queue.offer(queue2, 1), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
+      yield* $(Queue.offer(queue2, 2), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
+      yield* $(Queue.shutdown(queue2), Effect.zipRight(TestClock.adjust(Duration.seconds(1))))
       yield* $(Queue.offer(queue1, 3))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [1, 2])
@@ -96,12 +96,12 @@ describe.concurrent("Stream", () => {
       const queue2 = yield* $(Queue.unbounded<number>())
       const stream1 = Stream.fromQueue(queue1)
       const stream2 = Stream.fromQueue(queue2)
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         stream1,
         Stream.merge(stream2, { haltStrategy: "either" }),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Queue.shutdown(queue1))
       yield* $(TestClock.adjust(Duration.seconds(1)))
       yield* $(Queue.offer(queue2, 1))
@@ -134,12 +134,12 @@ describe.concurrent("Stream", () => {
 
   it.effect("merge - fails as soon as one stream fails", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.merge(Stream.fail(void 0)),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.isTrue(Exit.isFailure(result))
     }))
 
@@ -147,12 +147,12 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const stream1 = Stream.never
       const stream2 = Stream.fail("Ouch")
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream1,
         Stream.mergeWith(stream2, { onSelf: constVoid, onOther: constVoid }),
         Stream.runCollect,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 })

--- a/test/Stream/pagination.ts
+++ b/test/Stream/pagination.ts
@@ -1,5 +1,4 @@
 import * as Chunk from "@effect/data/Chunk"
-import { pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import * as Effect from "@effect/io/Effect"
 import * as Stream from "@effect/stream/Stream"
@@ -10,20 +9,20 @@ describe.concurrent("Stream", () => {
   it.effect("paginate", () =>
     Effect.gen(function*($) {
       const s: readonly [number, Array<number>] = [0, [1, 2, 3]]
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.paginate(s, ([n, nums]) =>
           nums.length === 0 ?
             [n, Option.none()] as const :
             [n, Option.some([nums[0], nums.slice(1)] as const)] as const),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1, 2, 3])
     }))
 
   it.effect("paginateEffect", () =>
     Effect.gen(function*($) {
       const s: readonly [number, Array<number>] = [0, [1, 2, 3]]
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.paginateEffect(
           s,
           (
@@ -34,7 +33,7 @@ describe.concurrent("Stream", () => {
               Effect.succeed([n, Option.some([nums[0], nums.slice(1)])])
         ),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1, 2, 3])
     }))
 
@@ -42,7 +41,7 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const s: readonly [Chunk.Chunk<number>, Array<number>] = [Chunk.of(0), [1, 2, 3, 4, 5]]
       const pageSize = 2
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.paginateChunk(s, ([chunk, nums]) =>
           nums.length === 0 ?
             [chunk, Option.none()] as const :
@@ -56,7 +55,7 @@ describe.concurrent("Stream", () => {
               )
             ] as const),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1, 2, 3, 4, 5])
     }))
 
@@ -64,7 +63,7 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const s: readonly [Chunk.Chunk<number>, Array<number>] = [Chunk.of(0), [1, 2, 3, 4, 5]]
       const pageSize = 2
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.paginateChunkEffect(s, ([chunk, nums]) =>
           nums.length === 0 ?
             Effect.succeed([chunk, Option.none<readonly [Chunk.Chunk<number>, Array<number>]>()] as const) :
@@ -80,7 +79,7 @@ describe.concurrent("Stream", () => {
               ] as const
             )),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1, 2, 3, 4, 5])
     }))
 })

--- a/test/Stream/partitioning.ts
+++ b/test/Stream/partitioning.ts
@@ -19,16 +19,16 @@ describe.concurrent("Stream", () => {
         Effect.flatMap(Stream.runCollect),
         Effect.scoped
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.all(Array.from({ length: 100 }, () => stream)),
         Effect.as(0)
-      ))
+      )
       assert.strictEqual(result, 0)
     }))
 
   it.effect("partition - values", () =>
     Effect.gen(function*($) {
-      const { result1, result2 } = yield* $(pipe(
+      const { result1, result2 } = yield* $(
         Stream.range(0, 6),
         Stream.partition((n) => n % 2 === 0),
         Effect.flatMap(([evens, odds]) =>
@@ -38,14 +38,14 @@ describe.concurrent("Stream", () => {
           })
         ),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(Array.from(result1), [0, 2, 4])
       assert.deepStrictEqual(Array.from(result2), [1, 3, 5])
     }))
 
   it.effect("partition - errors", () =>
     Effect.gen(function*($) {
-      const { result1, result2 } = yield* $(pipe(
+      const { result1, result2 } = yield* $(
         Stream.range(0, 1),
         Stream.concat(Stream.fail("boom")),
         Stream.partition((n) => n % 2 === 0),
@@ -56,21 +56,21 @@ describe.concurrent("Stream", () => {
           })
         ),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(result1, Either.left("boom"))
       assert.deepStrictEqual(result2, Either.left("boom"))
     }))
 
   it.effect("partition - backpressure", () =>
     Effect.gen(function*($) {
-      const { result1, result2, result3 } = yield* $(pipe(
+      const { result1, result2, result3 } = yield* $(
         Stream.range(0, 6),
         Stream.partition((n) => (n % 2 === 0), { bufferSize: 1 }),
         Effect.flatMap(([evens, odds]) =>
           Effect.gen(function*($) {
             const ref = yield* $(Ref.make(Chunk.empty<number>()))
             const latch = yield* $(Deferred.make<never, void>())
-            const fiber = yield* $(pipe(
+            const fiber = yield* $(
               evens,
               Stream.tap((n) =>
                 pipe(
@@ -85,7 +85,7 @@ describe.concurrent("Stream", () => {
               ),
               Stream.runDrain,
               Effect.fork
-            ))
+            )
             yield* $(Deferred.await(latch))
             const result1 = yield* $(Ref.get(ref))
             const result2 = yield* $(Stream.runCollect(odds))
@@ -95,7 +95,7 @@ describe.concurrent("Stream", () => {
           })
         ),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(Array.from(result1), [2, 0])
       assert.deepStrictEqual(Array.from(result2), [1, 3, 5])
       assert.deepStrictEqual(Array.from(result3), [4, 2, 0])

--- a/test/Stream/peeling.ts
+++ b/test/Stream/peeling.ts
@@ -11,7 +11,7 @@ describe.concurrent("Stream", () => {
   it.effect("peel", () =>
     Effect.gen(function*($) {
       const sink = Sink.take<number>(3)
-      const [peeled, rest] = yield* $(pipe(
+      const [peeled, rest] = yield* $(
         Stream.fromChunks(Chunk.range(1, 3), Chunk.range(4, 6)),
         Stream.peel(sink),
         Effect.flatMap(([peeled, rest]) =>
@@ -21,7 +21,7 @@ describe.concurrent("Stream", () => {
           )
         ),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(Array.from(peeled), [1, 2, 3])
       assert.deepStrictEqual(Array.from(rest), [4, 5, 6])
     }))
@@ -34,12 +34,12 @@ describe.concurrent("Stream", () => {
         constTrue,
         Chunk.append
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.peel(sink),
         Effect.exit,
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("fail"))
     }))
 })

--- a/test/Stream/retrying.ts
+++ b/test/Stream/retrying.ts
@@ -20,12 +20,12 @@ describe.concurrent("Stream", () => {
         Stream.fromEffect(Ref.getAndUpdate(ref, (n) => n + 1)),
         Stream.concat(Stream.fail(Option.none()))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.retry(Schedule.forever),
         Stream.take(2),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1])
     }))
 
@@ -42,12 +42,12 @@ describe.concurrent("Stream", () => {
         ),
         Stream.unwrapScoped
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.retry(Schedule.forever),
         Stream.take(2),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 1])
     }))
 
@@ -63,17 +63,17 @@ describe.concurrent("Stream", () => {
         ),
         Stream.flatMap(() => Stream.fail(Option.none()))
       )
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         stream,
         Stream.retry(Schedule.exponential(Duration.seconds(1))),
         Stream.take(3),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(1)))
       yield* $(TestClock.adjust(Duration.seconds(2)))
       yield* $(Fiber.interrupt(fiber))
-      const result = yield* $(pipe(Ref.get(ref), Effect.map(Chunk.map((n) => new Date(n).getSeconds()))))
+      const result = yield* $(Ref.get(ref), Effect.map(Chunk.map((n) => new Date(n).getSeconds())))
       assert.deepStrictEqual(Array.from(result), [3, 1, 0])
     }))
 
@@ -99,13 +99,13 @@ describe.concurrent("Stream", () => {
         ),
         Stream.forever
       )
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         stream,
         Stream.retry(Schedule.exponential(Duration.seconds(1))),
         Stream.take(2),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(1)))
       yield* $(TestClock.adjust(Duration.seconds(2)))
       yield* $(TestClock.adjust(Duration.seconds(1)))

--- a/test/Stream/scanning.ts
+++ b/test/Stream/scanning.ts
@@ -28,11 +28,11 @@ describe.concurrent("Stream", () => {
   it.effect("scanReduce", () =>
     Effect.gen(function*($) {
       const stream = Stream.make(1, 2, 3, 4, 5)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.scanReduce<number, number>((acc, curr) => acc + curr),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 3, 6, 10, 15])
     }))
 })

--- a/test/Stream/scheduling.ts
+++ b/test/Stream/scheduling.ts
@@ -13,7 +13,7 @@ describe.concurrent("Stream", () => {
   it.effect("schedule", () =>
     Effect.gen(function*($) {
       const start = yield* $(Clock.currentTimeMillis)
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.range(1, 9),
         Stream.schedule(Schedule.fixed(Duration.millis(100))),
         Stream.mapEffect((n) =>
@@ -24,7 +24,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.millis(800)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [
@@ -45,11 +45,11 @@ describe.concurrent("Stream", () => {
         Schedule.recurs(2),
         Schedule.zipRight(Schedule.fromFunction<string, string>(() => "Done"))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make("A", "B", "C", "A", "B", "C"),
         Stream.scheduleWith(schedule, { onElement: (s) => s.toLowerCase(), onSchedule: identity }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), ["a", "b", "c", "Done", "a", "b", "c", "Done"])
     }))
 })

--- a/test/Stream/sliding.ts
+++ b/test/Stream/sliding.ts
@@ -35,31 +35,31 @@ describe.concurrent("Stream", () => {
         Stream.concat(Stream.fromChunk(Chunk.make(2))),
         Stream.concat(Stream.make(3, 4, 5))
       )
-      const result1 = yield* $(pipe(
+      const result1 = yield* $(
         Stream.make(1, 2, 3, 4, 5),
         Stream.sliding(2),
         Stream.runCollect
-      ))
-      const result2 = yield* $(pipe(
+      )
+      const result2 = yield* $(
         stream0,
         Stream.sliding(2),
         Stream.runCollect
-      ))
-      const result3 = yield* $(pipe(
+      )
+      const result3 = yield* $(
         stream1,
         Stream.sliding(2),
         Stream.runCollect
-      ))
-      const result4 = yield* $(pipe(
+      )
+      const result4 = yield* $(
         stream2,
         Stream.sliding(2),
         Stream.runCollect
-      ))
-      const result5 = yield* $(pipe(
+      )
+      const result5 = yield* $(
         stream3,
         Stream.sliding(2),
         Stream.runCollect
-      ))
+      )
       const expected = [[1, 2], [2, 3], [3, 4], [4, 5]]
       assert.deepStrictEqual(Array.from(result1).map((chunk) => Array.from(chunk)), expected)
       assert.deepStrictEqual(Array.from(result2).map((chunk) => Array.from(chunk)), expected)
@@ -70,11 +70,11 @@ describe.concurrent("Stream", () => {
 
   it.effect("sliding - returns all elements if chunkSize is greater than the size of the stream", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.range(1, 6),
         Stream.sliding(6),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result).map((chunk) => Array.from(chunk)), [[1, 2, 3, 4, 5]])
     }))
 
@@ -93,20 +93,20 @@ describe.concurrent("Stream", () => {
 
   it.effect("sliding - fails if upstream produces an error", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.concat(Stream.fail("Ouch")),
         Stream.concat(Stream.make(4, 5)),
         Stream.sliding(2),
         Stream.runCollect,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
   it.effect("sliding - should return an empty chunk when the stream is empty", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(Stream.empty, Stream.sliding(2), Stream.runCollect))
+      const result = yield* $(Stream.empty, Stream.sliding(2), Stream.runCollect)
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
@@ -123,12 +123,12 @@ describe.concurrent("Stream", () => {
         Stream.concat(Stream.fail("Ouch")),
         Stream.slidingSize(3, 3)
       )
-      const either = yield* $(pipe(
+      const either = yield* $(
         stream,
         Stream.mapEffect((chunk) => Ref.update(ref, Chunk.append(chunk))),
         Stream.runCollect,
         Effect.either
-      ))
+      )
       const result = yield* $(Ref.get(ref))
       assert.deepStrictEqual(either, Either.left("Ouch"))
       assert.deepStrictEqual(

--- a/test/Stream/splitting.ts
+++ b/test/Stream/splitting.ts
@@ -82,11 +82,11 @@ describe.concurrent("Stream", () => {
 
   it.effect("split - should output empty chunk when stream is empty", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.empty,
         Stream.split((n: number) => n % 11 === 0),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
@@ -99,12 +99,12 @@ describe.concurrent("Stream", () => {
         Chunk.make(1, 2)
       )
       const splitSequence = Chunk.make(1, 2)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.flattenChunks(input),
         Stream.splitOnChunk(splitSequence),
         Stream.map(Chunk.size),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [0, 0, 0, 1, 0])
     }))
 
@@ -112,23 +112,23 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const splitSequence = Chunk.make(0, 1)
       const stream = Stream.make(1, 1, 1, 1, 1, 1)
-      const result = yield* $(pipe(
+      const result = yield* $(
         stream,
         Stream.splitOnChunk(splitSequence),
         Stream.runCollect,
         Effect.map(Chunk.flatten)
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 1, 1, 1, 1, 1])
     }))
 
   it.effect("splitOnChunk - handles leftovers", () =>
     Effect.gen(function*($) {
       const splitSequence = Chunk.make(0, 1)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(Chunk.make(1, 0, 2, 0, 1, 2), Chunk.of(2)),
         Stream.splitOnChunk(splitSequence),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1, 0, 2], [2, 2]]
@@ -138,11 +138,11 @@ describe.concurrent("Stream", () => {
   it.effect("splitOnChunk - works", () =>
     Effect.gen(function*($) {
       const splitSequence = Chunk.make(0, 1)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 0, 1, 3, 4, 0, 1, 5, 6, 5, 6),
         Stream.splitOnChunk(splitSequence),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1, 2], [3, 4], [5, 6, 5, 6]]
@@ -152,7 +152,7 @@ describe.concurrent("Stream", () => {
   it.effect("splitOnChunk - works from Chunks", () =>
     Effect.gen(function*($) {
       const splitSequence = Chunk.make(0, 1)
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(
           Chunk.make(1, 2),
           splitSequence,
@@ -163,7 +163,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.splitOnChunk(splitSequence),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1, 2], [3, 4], [5, 6, 5, 6]]
@@ -172,11 +172,11 @@ describe.concurrent("Stream", () => {
 
   it.effect("splitOnChunk - single delimiter edge case", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(0),
         Stream.splitOnChunk(Chunk.make(0)),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[]]
@@ -185,11 +185,11 @@ describe.concurrent("Stream", () => {
 
   it.effect("splitOnChunk - no delimiter in data", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(Chunk.make(1, 2), Chunk.make(1, 2), Chunk.make(1, 2)),
         Stream.splitOnChunk(Chunk.make(1, 1)),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1, 2, 1, 2, 1, 2]]
@@ -198,11 +198,11 @@ describe.concurrent("Stream", () => {
 
   it.effect("splitOnChunk - delimiter on the boundary", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(Chunk.make(1, 2), Chunk.make(1, 2)),
         Stream.splitOnChunk(Chunk.make(2, 1)),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(
         Array.from(result).map((chunk) => Array.from(chunk)),
         [[1], [2]]

--- a/test/Stream/taking.ts
+++ b/test/Stream/taking.ts
@@ -34,18 +34,18 @@ describe.concurrent("Stream", () => {
 
   it.effect("take - taking 0 short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(Stream.never, Stream.take(0), Stream.runCollect))
+      const result = yield* $(Stream.never, Stream.take(0), Stream.runCollect)
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
   it.effect("take - taking 1 short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.concat(Stream.never),
         Stream.take(1),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
@@ -111,7 +111,7 @@ describe.concurrent("Stream", () => {
 
   it.effect("takeUntilEffect - laziness on chunks", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.takeUntilEffect((n) =>
           n === 2 ?
@@ -120,7 +120,7 @@ describe.concurrent("Stream", () => {
         ),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [Either.right(1), Either.left("boom")])
     }))
 
@@ -137,7 +137,7 @@ describe.concurrent("Stream", () => {
 
   it.effect("takeWhile - does not stop when hitting an empty chunk (ZIO #4272)", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromChunks(Chunk.of(1), Chunk.of(2), Chunk.of(3)),
         Stream.mapChunks(Chunk.flatMap((n) =>
           n === 2 ?
@@ -146,18 +146,18 @@ describe.concurrent("Stream", () => {
         )),
         Stream.takeWhile((n) => n !== 4),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 3])
     }))
 
   it.effect("takeWhile - short circuits", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1),
         Stream.concat(Stream.fail("Ouch")),
         Stream.takeWhile(constFalse),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [])
     }))
 })

--- a/test/Stream/tapping.ts
+++ b/test/Stream/tapping.ts
@@ -12,11 +12,11 @@ describe.concurrent("Stream", () => {
   it.effect("tap", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(0))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 1),
         Stream.tap((i) => Ref.update(ref, (n) => i + n)),
         Stream.runCollect
-      ))
+      )
       const sum = yield* $(Ref.get(ref))
       assert.strictEqual(sum, 2)
       assert.deepStrictEqual(Array.from(result), [1, 1])
@@ -24,12 +24,12 @@ describe.concurrent("Stream", () => {
 
   it.effect("tap - laziness on chunks", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.tap((n) => pipe(Effect.fail("error"), Effect.when(() => n === 3))),
         Stream.either,
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [
         Either.right(1),
         Either.right(2),
@@ -114,13 +114,13 @@ describe.concurrent("Stream", () => {
   it.effect("tapError", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(""))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 1),
         Stream.concat(Stream.fail("Ouch")),
         Stream.tapError((e) => Ref.update(ref, (s) => s + e)),
         Stream.runCollect,
         Effect.either
-      ))
+      )
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
@@ -128,11 +128,11 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(0))
       const sink = Sink.forEach((i: number) => Ref.update(ref, (n) => i + n))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 1, 2, 3, 5, 8),
         Stream.tapSink(sink),
         Stream.runCollect
-      ))
+      )
       const sum = yield* $(Ref.get(ref))
       assert.strictEqual(sum, 20)
       assert.deepStrictEqual(Array.from(result), [1, 1, 2, 3, 5, 8])
@@ -146,12 +146,12 @@ describe.concurrent("Stream", () => {
         Sink.map(Chunk.reduce(0, (x, y) => x + y)),
         Sink.mapEffect((i) => Ref.update(ref, (n) => n + i))
       )
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 1, 2, 3, 5, 8),
         Stream.rechunk(1),
         Stream.tapSink(sink),
         Stream.runCollect
-      ))
+      )
       const sum = yield* $(Ref.get(ref))
       assert.strictEqual(sum, 4)
       assert.deepStrictEqual(Array.from(result), [1, 1, 2, 3, 5, 8])
@@ -160,12 +160,12 @@ describe.concurrent("Stream", () => {
   it.effect("tapSink - sink that fails before stream", () =>
     Effect.gen(function*($) {
       const sink = Sink.fail("error")
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.never,
         Stream.tapSink(sink),
         Stream.runCollect,
         Effect.flip
-      ))
+      )
       assert.strictEqual(result, "error")
     }))
 
@@ -173,14 +173,14 @@ describe.concurrent("Stream", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(0))
       const sink = Sink.forEach((i: number) => Ref.update(ref, (n) => i + n))
-      yield* $(pipe(
+      yield* $(
         Stream.make(1, 2, 3, 4, 5),
         Stream.rechunk(1),
         Stream.forever,
         Stream.tapSink(sink),
         Stream.take(3),
         Stream.runDrain
-      ))
+      )
       const result = yield* $(Ref.get(ref))
       assert.strictEqual(result, 6)
     }))

--- a/test/Stream/throttling.ts
+++ b/test/Stream/throttling.ts
@@ -18,21 +18,21 @@ import { assert, describe } from "vitest"
 describe.concurrent("Stream", () => {
   it.effect("throttleEnforce - free elements", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.throttle({ cost: () => 0, units: 0, duration: Duration.infinity, strategy: "enforce" }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4])
     }))
 
   it.effect("throttleEnforce - no bandwidth", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.throttle({ cost: () => 1, units: 0, duration: Duration.infinity, strategy: "enforce" }),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
@@ -53,7 +53,7 @@ describe.concurrent("Stream", () => {
   it.effect("throttleShape", () =>
     Effect.gen(function*($) {
       const queue = yield* $(Queue.bounded<number>(10))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(queue),
         Stream.throttle({
           strategy: "shape",
@@ -64,19 +64,19 @@ describe.concurrent("Stream", () => {
         Stream.toPull,
         Effect.flatMap((pull) =>
           Effect.gen(function*($) {
-            yield* $(pipe(Queue.offer(queue, 1)))
+            yield* $(Queue.offer(queue, 1))
             const result1 = yield* $(pull)
-            yield* $(pipe(Queue.offer(queue, 2)))
+            yield* $(Queue.offer(queue, 2))
             const result2 = yield* $(pull)
             yield* $(Effect.sleep(Duration.seconds(4)))
-            yield* $(pipe(Queue.offer(queue, 3)))
+            yield* $(Queue.offer(queue, 3))
             const result3 = yield* $(pull)
             return [Array.from(result1), Array.from(result2), Array.from(result3)] as const
           })
         ),
         Effect.scoped,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(8)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(result, [[1], [2], [3]])
@@ -85,7 +85,7 @@ describe.concurrent("Stream", () => {
   it.effect("throttleShape - infinite bandwidth", () =>
     Effect.gen(function*($) {
       const queue = yield* $(Queue.bounded<number>(10))
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromQueue(queue),
         Stream.throttle({
           strategy: "shape",
@@ -96,23 +96,23 @@ describe.concurrent("Stream", () => {
         Stream.toPull,
         Effect.flatMap((pull) =>
           Effect.gen(function*($) {
-            yield* $(pipe(Queue.offer(queue, 1)))
+            yield* $(Queue.offer(queue, 1))
             const result1 = yield* $(pull)
-            yield* $(pipe(Queue.offer(queue, 2)))
+            yield* $(Queue.offer(queue, 2))
             const result2 = yield* $(pull)
             const elapsed = yield* $(Clock.currentTimeMillis)
             return [Array.from(result1), Array.from(result2), elapsed] as const
           })
         ),
         Effect.scoped
-      ))
+      )
       assert.deepStrictEqual(result, [[1], [2], 0])
     }))
 
   it.effect("throttleShape - with burst", () =>
     Effect.gen(function*($) {
       const queue = yield* $(Queue.bounded<number>(10))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(queue),
         Stream.throttle({
           strategy: "shape",
@@ -124,27 +124,27 @@ describe.concurrent("Stream", () => {
         Stream.toPull,
         Effect.flatMap((pull) =>
           Effect.gen(function*($) {
-            yield* $(pipe(Queue.offer(queue, 1)))
+            yield* $(Queue.offer(queue, 1))
             const result1 = yield* $(pull)
             yield* $(TestClock.adjust(Duration.seconds(2)))
-            yield* $(pipe(Queue.offer(queue, 2)))
+            yield* $(Queue.offer(queue, 2))
             const result2 = yield* $(pull)
             yield* $(TestClock.adjust(Duration.seconds(4)))
-            yield* $(pipe(Queue.offer(queue, 3)))
+            yield* $(Queue.offer(queue, 3))
             const result3 = yield* $(pull)
             return [Array.from(result1), Array.from(result2), Array.from(result3)] as const
           })
         ),
         Effect.scoped,
         Effect.fork
-      ))
+      )
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(result, [[1], [2], [3]])
     }))
 
   it.effect("throttleShape - free elements", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.make(1, 2, 3, 4),
         Stream.throttle({
           strategy: "shape",
@@ -153,7 +153,7 @@ describe.concurrent("Stream", () => {
           duration: Duration.infinity
         }),
         Stream.runCollect
-      ))
+      )
       assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4])
     }))
 
@@ -174,23 +174,23 @@ describe.concurrent("Stream", () => {
         Stream.debounce(Duration.seconds(1)),
         Stream.tap(() => coordination.proceed)
       )
-      const fiber = yield* $(pipe(stream, Stream.runCollect, Effect.fork))
+      const fiber = yield* $(stream, Stream.runCollect, Effect.fork)
       yield* $(Effect.fork(coordination.offer))
-      yield* $(pipe(
+      yield* $(
         Effect.sleep(Duration.millis(500)),
         Effect.zipRight(coordination.offer),
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         Effect.sleep(Duration.seconds(2)),
         Effect.zipRight(coordination.offer),
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         Effect.sleep(Duration.millis(2500)),
         Effect.zipRight(coordination.offer),
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.millis(3500)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(
@@ -212,12 +212,12 @@ describe.concurrent("Stream", () => {
         Stream.debounce(Duration.seconds(1)),
         Stream.tap(() => coordination.proceed)
       )
-      const fiber = yield* $(pipe(stream, Stream.runCollect, Effect.fork))
-      yield* $(pipe(
+      const fiber = yield* $(stream, Stream.runCollect, Effect.fork)
+      yield* $(
         coordination.offer,
         Effect.zipRight(coordination.offer),
         Effect.zipRight(coordination.offer)
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(1)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(
@@ -239,7 +239,7 @@ describe.concurrent("Stream", () => {
         Stream.debounce(Duration.seconds(1)),
         Stream.tap(() => coordination.proceed)
       )
-      const fiber = yield* $(pipe(stream, Stream.runCollect, Effect.fork))
+      const fiber = yield* $(stream, Stream.runCollect, Effect.fork)
       yield* $(Effect.all([
         coordination.offer,
         coordination.offer,
@@ -255,13 +255,13 @@ describe.concurrent("Stream", () => {
 
   it.effect("debounce - should handle empty chunks properly", () =>
     Effect.gen(function*($) {
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.make(1, 2, 3),
         Stream.schedule(Schedule.fixed(Duration.millis(500))),
         Stream.debounce(Duration.seconds(1)),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(3)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [3])
@@ -269,33 +269,33 @@ describe.concurrent("Stream", () => {
 
   it.effect("debounce - should fail immediately", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.fromEffect(Effect.fail(Option.none())),
         Stream.debounce(Duration.infinity),
         Stream.runCollect,
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(Option.none()))
     }))
 
   it.effect("debounce - should work with empty streams", () =>
     Effect.gen(function*($) {
-      const result = yield* $(pipe(
+      const result = yield* $(
         Stream.empty,
         Stream.debounce(Duration.seconds(5)),
         Stream.runCollect
-      ))
+      )
       assert.isTrue(Chunk.isEmpty(result))
     }))
 
   it.effect("debounce - should pick last element from every chunk", () =>
     Effect.gen(function*($) {
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.make(1, 2, 3),
         Stream.debounce(Duration.seconds(1)),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.seconds(1)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [3])
@@ -308,7 +308,7 @@ describe.concurrent("Stream", () => {
         Chunk.of(2),
         Chunk.of(3)
       ]))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromQueue(coordination.queue),
         Stream.tap(() => coordination.proceed),
         // TODO: remove
@@ -319,13 +319,13 @@ describe.concurrent("Stream", () => {
         Stream.take(1),
         Stream.runCollect,
         Effect.fork
-      ))
-      yield* $(pipe(
+      )
+      yield* $(
         coordination.offer,
         Effect.zipRight(TestClock.adjust(Duration.millis(100))),
         Effect.zipRight(coordination.awaitNext),
         Effect.repeatN(3)
-      ))
+      )
       yield* $(TestClock.adjust(Duration.millis(100)))
       const result = yield* $(Fiber.join(fiber))
       assert.deepStrictEqual(Array.from(result), [3])
@@ -334,7 +334,7 @@ describe.concurrent("Stream", () => {
   it.effect("debounce - should interrupt children fiber on stream interruption", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         Stream.fromEffect(Effect.unit),
         Stream.concat(Stream.fromEffect(pipe(
           Effect.never,
@@ -343,7 +343,7 @@ describe.concurrent("Stream", () => {
         Stream.debounce(Duration.millis(800)),
         Stream.runDrain,
         Effect.fork
-      ))
+      )
       yield* $(TestClock.adjust(Duration.minutes(1)))
       yield* $(Fiber.interrupt(fiber))
       const result = yield* $(Ref.get(ref))

--- a/test/Stream/transducing.ts
+++ b/test/Stream/transducing.ts
@@ -11,17 +11,15 @@ describe.concurrent("Stream", () => {
   it.effect("transduce - simple example", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make("1", "2", ",", "3", "4"),
-          Stream.transduce(
-            pipe(
-              Sink.collectAllWhile((char: string) => Number.isInteger(Number.parseInt(char))),
-              Sink.zipLeft(Sink.collectAllWhile((char: string) => !Number.isInteger(Number.parseInt(char))))
-            )
-          ),
-          Stream.map(Chunk.join("")),
-          Stream.runCollect
-        )
+        Stream.make("1", "2", ",", "3", "4"),
+        Stream.transduce(
+          pipe(
+            Sink.collectAllWhile((char: string) => Number.isInteger(Number.parseInt(char))),
+            Sink.zipLeft(Sink.collectAllWhile((char: string) => !Number.isInteger(Number.parseInt(char))))
+          )
+        ),
+        Stream.map(Chunk.join("")),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), ["12", "34"])
     }))
@@ -29,11 +27,9 @@ describe.concurrent("Stream", () => {
   it.effect("transduce - no remainder", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3, 4),
-          Stream.transduce(Sink.fold(100, (n) => n % 2 === 0, (acc, n) => acc + n)),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3, 4),
+        Stream.transduce(Sink.fold(100, (n) => n % 2 === 0, (acc, n) => acc + n)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [101, 105, 104])
     }))
@@ -41,11 +37,9 @@ describe.concurrent("Stream", () => {
   it.effect("transduce - with a sink that always signals more", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3),
-          Stream.transduce(Sink.fold(0, constTrue, (acc, n) => acc + n)),
-          Stream.runCollect
-        )
+        Stream.make(1, 2, 3),
+        Stream.transduce(Sink.fold(0, constTrue, (acc, n) => acc + n)),
+        Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [6])
     }))
@@ -53,12 +47,10 @@ describe.concurrent("Stream", () => {
   it.effect("transduce - propagates scope error", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        pipe(
-          Stream.make(1, 2, 3),
-          Stream.transduce(Sink.fail("Woops")),
-          Stream.runCollect,
-          Effect.either
-        )
+        Stream.make(1, 2, 3),
+        Stream.transduce(Sink.fail("Woops")),
+        Stream.runCollect,
+        Effect.either
       )
       assert.deepStrictEqual(result, Either.left("Woops"))
     }))

--- a/test/SubscriptionRef.ts
+++ b/test/SubscriptionRef.ts
@@ -18,22 +18,22 @@ describe.concurrent("SubscriptionRef", () => {
       const subscriptionRef = yield* $(SubscriptionRef.make(0))
       const deferred1 = yield* $(Deferred.make<never, void>())
       const deferred2 = yield* $(Deferred.make<never, void>())
-      const subscriber1 = yield* $(pipe(
+      const subscriber1 = yield* $(
         subscriptionRef.changes,
         Stream.tap(() => Deferred.succeed<never, void>(deferred1, void 0)),
         Stream.take(3),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(deferred1))
       yield* $(SubscriptionRef.update(subscriptionRef, (n) => n + 1))
-      const subscriber2 = yield* $(pipe(
+      const subscriber2 = yield* $(
         subscriptionRef.changes,
         Stream.tap(() => Deferred.succeed<never, void>(deferred2, void 0)),
         Stream.take(2),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(deferred2))
       yield* $(SubscriptionRef.update(subscriptionRef, (n) => n + 1))
       const result1 = yield* $(Fiber.join(subscriber1))
@@ -47,22 +47,22 @@ describe.concurrent("SubscriptionRef", () => {
       const subscriptionRef = yield* $(SubscriptionRef.make(0))
       const deferred1 = yield* $(Deferred.make<never, void>())
       const deferred2 = yield* $(Deferred.make<never, void>())
-      const subscriber1 = yield* $(pipe(
+      const subscriber1 = yield* $(
         subscriptionRef.changes,
         Stream.tap(() => Deferred.succeed<never, void>(deferred1, void 0)),
         Stream.take(5),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(deferred1))
       yield* $(SubscriptionRef.update(subscriptionRef, (n) => n + 1))
-      const subscriber2 = yield* $(pipe(
+      const subscriber2 = yield* $(
         subscriptionRef.changes,
         Stream.tap(() => Deferred.succeed<never, void>(deferred2, void 0)),
         Stream.take(2),
         Stream.runCollect,
         Effect.fork
-      ))
+      )
       yield* $(Deferred.await(deferred2))
       yield* $(SubscriptionRef.update(subscriptionRef, (n) => n + 1))
       const result1 = yield* $(Fiber.interrupt(subscriber1))
@@ -85,11 +85,11 @@ describe.concurrent("SubscriptionRef", () => {
           )
         )
       const subscriptionRef = yield* $(SubscriptionRef.make(0))
-      const fiber = yield* $(pipe(
+      const fiber = yield* $(
         SubscriptionRef.update(subscriptionRef, (n) => n + 1),
         Effect.forever,
         Effect.fork
-      ))
+      )
       const result = yield* $(
         Effect.map(
           Effect.all(


### PR DESCRIPTION
... just some house keeping.

This removes all the redundant `pipe()` calls.