### PR TITLE
fix: return-type of fromPull should exclude Scope

### DIFF
--- a/.changeset/calm-eyes-attack.md
+++ b/.changeset/calm-eyes-attack.md
@@ -1,0 +1,5 @@
+---
+"@effect/stream": patch
+---
+
+Fix return-type signature of fromPull

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -1540,7 +1540,7 @@ export const fromIteratorSucceed: <A>(iterator: IterableIterator<A>, maxChunkSiz
  */
 export const fromPull: <R, R2, E, A>(
   effect: Effect.Effect<Scope.Scope | R, never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
-) => Stream<R | R2, E, A> = internal.fromPull
+) => Stream<Exclude<R, Scope.Scope> | R2, E, A> = internal.fromPull
 
 /**
  * Creates a stream from a queue of values

--- a/src/internal/stream.ts
+++ b/src/internal/stream.ts
@@ -3007,7 +3007,7 @@ export const fromIteratorSucceed = <A>(
 /** @internal */
 export const fromPull = <R, R2, E, A>(
   effect: Effect.Effect<R | Scope.Scope, never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
-): Stream.Stream<R | R2, E, A> => pipe(effect, Effect.map(repeatEffectChunkOption), unwrapScoped)
+): Stream.Stream<Exclude<R, Scope.Scope> | R2, E, A> => pipe(effect, Effect.map(repeatEffectChunkOption), unwrapScoped)
 
 /** @internal */
 export const fromQueue = <A>(


### PR DESCRIPTION
It was pointed out in discord this signature wasn't working properly, and it seems it just doesn't have types that match up with `unwrapScoped` Excluding the Scope.

Discord: https://discord.com/channels/795981131316985866/796155116667273227/1145677947932524554