### PR TITLE
fix `Effect.forEach` usage

### DIFF
--- a/src/internal/sink.ts
+++ b/src/internal/sink.ts
@@ -377,7 +377,7 @@ export const contramapEffect = dual<
       self,
       (chunk) =>
         Effect.map(
-          Effect.forEach(chunk, f),
+          Effect.forEach(chunk, (v) => f(v)),
           Chunk.unsafeFromArray
         )
     )
@@ -1375,7 +1375,7 @@ export const flatMap = dual<
 export const forEach = <In, R, E, _>(f: (input: In) => Effect.Effect<R, E, _>): Sink.Sink<R, E, In, never, void> => {
   const process: Channel.Channel<R, E, Chunk.Chunk<In>, unknown, E, never, void> = core.readWithCause({
     onInput: (input: Chunk.Chunk<In>) =>
-      pipe(core.fromEffect(Effect.forEach(input, f, { discard: true })), core.flatMap(() => process)),
+      pipe(core.fromEffect(Effect.forEach(input, (v) => f(v), { discard: true })), core.flatMap(() => process)),
     onFailure: core.failCause,
     onDone: () => core.unit
   })


### PR DESCRIPTION
`Effect.forEach` has the callback signature `f`:

```ts
f: (a: A, i: number) => Effect<R, E, B>,
``` 

But `.runForEach` and `.contramapEffect` don't expect a second parameter. Hence, when using it in combination with something like `Effect.log` which has an optional second parameter, we'll pass the second parameter incorrectly.

This fixes https://github.com/Effect-TS/io/issues/639