### PR TITLE
rename contramap* functions to mapInput* functions, closes #180

### DIFF
--- a/.changeset/nasty-experts-provide.md
+++ b/.changeset/nasty-experts-provide.md
@@ -1,0 +1,21 @@
+---
+"@effect/stream": minor
+---
+
+rename contramap* functions to mapInput* functions:
+
+- Channel
+  - contramap
+  - contramapEffect
+  - contramapError
+  - contramapErrorEffect
+  - contramapIn
+  - contramapInEffect
+  - contramapContext
+- Sink
+  - contramap
+  - contramapEffect
+  - contramapChunks
+  - contramapChunksEffect
+- Stream
+  - contramapContext

--- a/docs/modules/Channel.ts.md
+++ b/docs/modules/Channel.ts.md
@@ -50,7 +50,7 @@ Added in v1.0.0
   - [contextWith](#contextwith)
   - [contextWithChannel](#contextwithchannel)
   - [contextWithEffect](#contextwitheffect)
-  - [contramapContext](#contramapcontext)
+  - [mapInputContext](#mapinputcontext)
   - [provideContext](#providecontext)
   - [provideLayer](#providelayer)
   - [provideService](#provideservice)
@@ -109,12 +109,6 @@ Added in v1.0.0
   - [concatMapWith](#concatmapwith)
   - [concatMapWithCustom](#concatmapwithcustom)
   - [concatOut](#concatout)
-  - [contramap](#contramap)
-  - [contramapEffect](#contramapeffect)
-  - [contramapError](#contramaperror)
-  - [contramapErrorEffect](#contramaperroreffect)
-  - [contramapIn](#contramapin)
-  - [contramapInEffect](#contramapineffect)
   - [doneCollect](#donecollect)
   - [drain](#drain)
   - [embedInput](#embedinput)
@@ -125,6 +119,12 @@ Added in v1.0.0
   - [foldChannel](#foldchannel)
   - [interruptWhen](#interruptwhen)
   - [interruptWhenDeferred](#interruptwhendeferred)
+  - [mapInput](#mapinput)
+  - [mapInputEffect](#mapinputeffect)
+  - [mapInputError](#mapinputerror)
+  - [mapInputErrorEffect](#mapinputerroreffect)
+  - [mapInputIn](#mapinputin)
+  - [mapInputInEffect](#mapinputineffect)
   - [mergeAll](#mergeall)
   - [mergeAllUnbounded](#mergeallunbounded)
   - [mergeAllUnboundedWith](#mergeallunboundedwith)
@@ -696,7 +696,7 @@ export declare const contextWithEffect: <Env, Env1, OutErr, OutDone>(
 
 Added in v1.0.0
 
-## contramapContext
+## mapInputContext
 
 Transforms the context being provided to the channel with the specified
 function.
@@ -704,7 +704,7 @@ function.
 **Signature**
 
 ```ts
-export declare const contramapContext: {
+export declare const mapInputContext: {
   <Env0, Env>(f: (env: Context.Context<Env0>) => Context.Context<Env>): <
     InErr,
     InElem,
@@ -1863,150 +1863,6 @@ export declare const concatOut: <Env, InErr, InElem, InDone, OutErr, OutElem, Ou
 
 Added in v1.0.0
 
-## contramap
-
-Returns a new channel which is the same as this one but applies the given
-function to the input channel's done value.
-
-**Signature**
-
-```ts
-export declare const contramap: {
-  <InDone0, InDone>(f: (a: InDone0) => InDone): <Env, InErr, InElem, OutErr, OutElem, OutDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-  <Env, InErr, InElem, OutErr, OutElem, OutDone, InDone0, InDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (a: InDone0) => InDone
-  ): Channel<Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
-## contramapEffect
-
-Returns a new channel which is the same as this one but applies the given
-effectual function to the input channel's done value.
-
-**Signature**
-
-```ts
-export declare const contramapEffect: {
-  <Env1, InErr, InDone0, InDone>(f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>): <
-    Env,
-    InElem,
-    OutErr,
-    OutElem,
-    OutDone
-  >(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env1 | Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-  <Env, InElem, OutErr, OutElem, OutDone, Env1, InErr, InDone0, InDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>
-  ): Channel<Env | Env1, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
-## contramapError
-
-Returns a new channel which is the same as this one but applies the given
-function to the input channel's error value.
-
-**Signature**
-
-```ts
-export declare const contramapError: {
-  <InErr0, InErr>(f: (a: InErr0) => InErr): <Env, InElem, InDone, OutErr, OutElem, OutDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-  <Env, InElem, InDone, OutErr, OutElem, OutDone, InErr0, InErr>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (a: InErr0) => InErr
-  ): Channel<Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
-## contramapErrorEffect
-
-Returns a new channel which is the same as this one but applies the given
-effectual function to the input channel's error value.
-
-**Signature**
-
-```ts
-export declare const contramapErrorEffect: {
-  <Env1, InErr0, InErr, InDone>(f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>): <
-    Env,
-    InElem,
-    OutErr,
-    OutElem,
-    OutDone
-  >(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env1 | Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-  <Env, InElem, OutErr, OutElem, OutDone, Env1, InErr0, InErr, InDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>
-  ): Channel<Env | Env1, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
-## contramapIn
-
-Returns a new channel which is the same as this one but applies the given
-function to the input channel's output elements.
-
-**Signature**
-
-```ts
-export declare const contramapIn: {
-  <InElem0, InElem>(f: (a: InElem0) => InElem): <Env, InErr, InDone, OutErr, OutElem, OutDone>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-  <Env, InErr, InDone, OutErr, OutElem, OutDone, InElem0, InElem>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (a: InElem0) => InElem
-  ): Channel<Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
-## contramapInEffect
-
-Returns a new channel which is the same as this one but applies the given
-effectual function to the input channel's output elements.
-
-**Signature**
-
-```ts
-export declare const contramapInEffect: {
-  <Env1, InErr, InElem0, InElem>(f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>): <
-    Env,
-    InDone,
-    OutErr,
-    OutElem,
-    OutDone
-  >(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel<Env1 | Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-  <Env, InDone, OutErr, OutElem, OutDone, Env1, InErr, InElem0, InElem>(
-    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
-    f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>
-  ): Channel<Env | Env1, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-}
-```
-
-Added in v1.0.0
-
 ## doneCollect
 
 Returns a new channel, which is the same as this one, except that all the
@@ -2359,6 +2215,150 @@ export declare const interruptWhenDeferred: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     deferred: Deferred.Deferred<OutErr1, OutDone1>
   ): Channel<Env, InErr, InElem, InDone, OutErr | OutErr1, OutElem, OutDone | OutDone1>
+}
+```
+
+Added in v1.0.0
+
+## mapInput
+
+Returns a new channel which is the same as this one but applies the given
+function to the input channel's done value.
+
+**Signature**
+
+```ts
+export declare const mapInput: {
+  <InDone0, InDone>(f: (a: InDone0) => InDone): <Env, InErr, InElem, OutErr, OutElem, OutDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
+  <Env, InErr, InElem, OutErr, OutElem, OutDone, InDone0, InDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (a: InDone0) => InDone
+  ): Channel<Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
+}
+```
+
+Added in v1.0.0
+
+## mapInputEffect
+
+Returns a new channel which is the same as this one but applies the given
+effectual function to the input channel's done value.
+
+**Signature**
+
+```ts
+export declare const mapInputEffect: {
+  <Env1, InErr, InDone0, InDone>(f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>): <
+    Env,
+    InElem,
+    OutErr,
+    OutElem,
+    OutDone
+  >(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env1 | Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
+  <Env, InElem, OutErr, OutElem, OutDone, Env1, InErr, InDone0, InDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>
+  ): Channel<Env | Env1, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
+}
+```
+
+Added in v1.0.0
+
+## mapInputError
+
+Returns a new channel which is the same as this one but applies the given
+function to the input channel's error value.
+
+**Signature**
+
+```ts
+export declare const mapInputError: {
+  <InErr0, InErr>(f: (a: InErr0) => InErr): <Env, InElem, InDone, OutErr, OutElem, OutDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
+  <Env, InElem, InDone, OutErr, OutElem, OutDone, InErr0, InErr>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (a: InErr0) => InErr
+  ): Channel<Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
+}
+```
+
+Added in v1.0.0
+
+## mapInputErrorEffect
+
+Returns a new channel which is the same as this one but applies the given
+effectual function to the input channel's error value.
+
+**Signature**
+
+```ts
+export declare const mapInputErrorEffect: {
+  <Env1, InErr0, InErr, InDone>(f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>): <
+    Env,
+    InElem,
+    OutErr,
+    OutElem,
+    OutDone
+  >(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env1 | Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
+  <Env, InElem, OutErr, OutElem, OutDone, Env1, InErr0, InErr, InDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>
+  ): Channel<Env | Env1, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
+}
+```
+
+Added in v1.0.0
+
+## mapInputIn
+
+Returns a new channel which is the same as this one but applies the given
+function to the input channel's output elements.
+
+**Signature**
+
+```ts
+export declare const mapInputIn: {
+  <InElem0, InElem>(f: (a: InElem0) => InElem): <Env, InErr, InDone, OutErr, OutElem, OutDone>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
+  <Env, InErr, InDone, OutErr, OutElem, OutDone, InElem0, InElem>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (a: InElem0) => InElem
+  ): Channel<Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
+}
+```
+
+Added in v1.0.0
+
+## mapInputInEffect
+
+Returns a new channel which is the same as this one but applies the given
+effectual function to the input channel's output elements.
+
+**Signature**
+
+```ts
+export declare const mapInputInEffect: {
+  <Env1, InErr, InElem0, InElem>(f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>): <
+    Env,
+    InDone,
+    OutErr,
+    OutElem,
+    OutDone
+  >(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel<Env1 | Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
+  <Env, InDone, OutErr, OutElem, OutDone, Env1, InErr, InElem0, InElem>(
+    self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+    f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>
+  ): Channel<Env | Env1, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
 }
 ```
 

--- a/docs/modules/Sink.ts.md
+++ b/docs/modules/Sink.ts.md
@@ -98,10 +98,6 @@ Added in v1.0.0
   - [foldSink](#foldsink)
 - [mapping](#mapping)
   - [as](#as)
-  - [contramap](#contramap)
-  - [contramapChunks](#contramapchunks)
-  - [contramapChunksEffect](#contramapchunkseffect)
-  - [contramapEffect](#contramapeffect)
   - [dimap](#dimap)
   - [dimapChunks](#dimapchunks)
   - [dimapChunksEffect](#dimapchunkseffect)
@@ -109,6 +105,10 @@ Added in v1.0.0
   - [map](#map)
   - [mapEffect](#mapeffect)
   - [mapError](#maperror)
+  - [mapInput](#mapinput)
+  - [mapInputChunks](#mapinputchunks)
+  - [mapInputChunksEffect](#mapinputchunkseffect)
+  - [mapInputEffect](#mapinputeffect)
   - [mapLeftover](#mapleftover)
 - [models](#models)
   - [Sink (interface)](#sink-interface)
@@ -1337,83 +1337,6 @@ export declare const as: {
 
 Added in v1.0.0
 
-## contramap
-
-Transforms this sink's input elements.
-
-**Signature**
-
-```ts
-export declare const contramap: (<In0, In>(
-  f: (input: In0) => In
-) => <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R, E, In0, L, Z>) &
-  (<R, E, L, Z, In0, In>(self: Sink<R, E, In, L, Z>, f: (input: In0) => In) => Sink<R, E, In0, L, Z>)
-```
-
-Added in v1.0.0
-
-## contramapChunks
-
-Transforms this sink's input chunks. `f` must preserve chunking-invariance.
-
-**Signature**
-
-```ts
-export declare const contramapChunks: {
-  <In0, In>(f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>): <R, E, L, Z>(
-    self: Sink<R, E, In, L, Z>
-  ) => Sink<R, E, In0, L, Z>
-  <R, E, L, Z, In0, In>(self: Sink<R, E, In, L, Z>, f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>): Sink<
-    R,
-    E,
-    In0,
-    L,
-    Z
-  >
-}
-```
-
-Added in v1.0.0
-
-## contramapChunksEffect
-
-Effectfully transforms this sink's input chunks. `f` must preserve
-chunking-invariance.
-
-**Signature**
-
-```ts
-export declare const contramapChunksEffect: {
-  <In0, R2, E2, In>(f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>): <R, E, L, Z>(
-    self: Sink<R, E, In, L, Z>
-  ) => Sink<R2 | R, E2 | E, In0, L, Z>
-  <R, E, L, Z, In0, R2, E2, In>(
-    self: Sink<R, E, In, L, Z>,
-    f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>
-  ): Sink<R | R2, E | E2, In0, L, Z>
-}
-```
-
-Added in v1.0.0
-
-## contramapEffect
-
-Effectfully transforms this sink's input elements.
-
-**Signature**
-
-```ts
-export declare const contramapEffect: (<In0, R2, E2, In>(
-  f: (input: In0) => Effect.Effect<R2, E2, In>
-) => <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R2 | R, E2 | E, In0, L, Z>) &
-  (<R, E, L, Z, In0, R2, E2, In>(
-    self: Sink<R, E, In, L, Z>,
-    f: (input: In0) => Effect.Effect<R2, E2, In>
-  ) => Sink<R | R2, E | E2, In0, L, Z>)
-```
-
-Added in v1.0.0
-
 ## dimap
 
 Transforms both inputs and result of this sink using the provided
@@ -1556,6 +1479,83 @@ export declare const mapError: {
   <E, E2>(f: (error: E) => E2): <R, In, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R, E2, In, L, Z>
   <R, In, L, Z, E, E2>(self: Sink<R, E, In, L, Z>, f: (error: E) => E2): Sink<R, E2, In, L, Z>
 }
+```
+
+Added in v1.0.0
+
+## mapInput
+
+Transforms this sink's input elements.
+
+**Signature**
+
+```ts
+export declare const mapInput: (<In0, In>(
+  f: (input: In0) => In
+) => <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R, E, In0, L, Z>) &
+  (<R, E, L, Z, In0, In>(self: Sink<R, E, In, L, Z>, f: (input: In0) => In) => Sink<R, E, In0, L, Z>)
+```
+
+Added in v1.0.0
+
+## mapInputChunks
+
+Transforms this sink's input chunks. `f` must preserve chunking-invariance.
+
+**Signature**
+
+```ts
+export declare const mapInputChunks: {
+  <In0, In>(f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>): <R, E, L, Z>(
+    self: Sink<R, E, In, L, Z>
+  ) => Sink<R, E, In0, L, Z>
+  <R, E, L, Z, In0, In>(self: Sink<R, E, In, L, Z>, f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>): Sink<
+    R,
+    E,
+    In0,
+    L,
+    Z
+  >
+}
+```
+
+Added in v1.0.0
+
+## mapInputChunksEffect
+
+Effectfully transforms this sink's input chunks. `f` must preserve
+chunking-invariance.
+
+**Signature**
+
+```ts
+export declare const mapInputChunksEffect: {
+  <In0, R2, E2, In>(f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>): <R, E, L, Z>(
+    self: Sink<R, E, In, L, Z>
+  ) => Sink<R2 | R, E2 | E, In0, L, Z>
+  <R, E, L, Z, In0, R2, E2, In>(
+    self: Sink<R, E, In, L, Z>,
+    f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>
+  ): Sink<R | R2, E | E2, In0, L, Z>
+}
+```
+
+Added in v1.0.0
+
+## mapInputEffect
+
+Effectfully transforms this sink's input elements.
+
+**Signature**
+
+```ts
+export declare const mapInputEffect: (<In0, R2, E2, In>(
+  f: (input: In0) => Effect.Effect<R2, E2, In>
+) => <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R2 | R, E2 | E, In0, L, Z>) &
+  (<R, E, L, Z, In0, R2, E2, In>(
+    self: Sink<R, E, In, L, Z>,
+    f: (input: In0) => Effect.Effect<R2, E2, In>
+  ) => Sink<R | R2, E | E2, In0, L, Z>)
 ```
 
 Added in v1.0.0

--- a/docs/modules/Stream.ts.md
+++ b/docs/modules/Stream.ts.md
@@ -84,7 +84,7 @@ Added in v1.0.0
   - [contextWith](#contextwith)
   - [contextWithEffect](#contextwitheffect)
   - [contextWithStream](#contextwithstream)
-  - [contramapContext](#contramapcontext)
+  - [mapInputContext](#mapinputcontext)
   - [provideContext](#providecontext)
   - [provideLayer](#providelayer)
   - [provideService](#provideservice)
@@ -1301,7 +1301,7 @@ export declare const contextWithStream: <R0, R, E, A>(
 
 Added in v1.0.0
 
-## contramapContext
+## mapInputContext
 
 Transforms the context being provided to the stream with the specified
 function.
@@ -1309,7 +1309,7 @@ function.
 **Signature**
 
 ```ts
-export declare const contramapContext: {
+export declare const mapInputContext: {
   <R0, R>(f: (env: Context.Context<R0>) => Context.Context<R>): <E, A>(self: Stream<R, E, A>) => Stream<R0, E, A>
   <E, A, R0, R>(self: Stream<R, E, A>, f: (env: Context.Context<R0>) => Context.Context<R>): Stream<R0, E, A>
 }

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -514,7 +514,7 @@ export const concatOut: <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
  * @since 1.0.0
  * @category utils
  */
-export const contramap: {
+export const mapInput: {
   <InDone0, InDone>(
     f: (a: InDone0) => InDone
   ): <Env, InErr, InElem, OutErr, OutElem, OutDone>(
@@ -524,7 +524,7 @@ export const contramap: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (a: InDone0) => InDone
   ): Channel<Env, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-} = channel.contramap
+} = channel.mapInput
 
 /**
  * Returns a new channel which is the same as this one but applies the given
@@ -533,7 +533,7 @@ export const contramap: {
  * @since 1.0.0
  * @category utils
  */
-export const contramapEffect: {
+export const mapInputEffect: {
   <Env1, InErr, InDone0, InDone>(
     f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>
   ): <Env, InElem, OutErr, OutElem, OutDone>(
@@ -543,7 +543,7 @@ export const contramapEffect: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>
   ): Channel<Env | Env1, InErr, InElem, InDone0, OutErr, OutElem, OutDone>
-} = channel.contramapEffect
+} = channel.mapInputEffect
 
 /**
  * Returns a new channel which is the same as this one but applies the given
@@ -552,7 +552,7 @@ export const contramapEffect: {
  * @since 1.0.0
  * @category utils
  */
-export const contramapError: {
+export const mapInputError: {
   <InErr0, InErr>(
     f: (a: InErr0) => InErr
   ): <Env, InElem, InDone, OutErr, OutElem, OutDone>(
@@ -562,7 +562,7 @@ export const contramapError: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (a: InErr0) => InErr
   ): Channel<Env, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-} = channel.contramapError
+} = channel.mapInputError
 
 /**
  * Returns a new channel which is the same as this one but applies the given
@@ -571,7 +571,7 @@ export const contramapError: {
  * @since 1.0.0
  * @category utils
  */
-export const contramapErrorEffect: {
+export const mapInputErrorEffect: {
   <Env1, InErr0, InErr, InDone>(
     f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>
   ): <Env, InElem, OutErr, OutElem, OutDone>(
@@ -581,7 +581,7 @@ export const contramapErrorEffect: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>
   ): Channel<Env | Env1, InErr0, InElem, InDone, OutErr, OutElem, OutDone>
-} = channel.contramapErrorEffect
+} = channel.mapInputErrorEffect
 
 /**
  * Returns a new channel which is the same as this one but applies the given
@@ -590,7 +590,7 @@ export const contramapErrorEffect: {
  * @since 1.0.0
  * @category utils
  */
-export const contramapIn: {
+export const mapInputIn: {
   <InElem0, InElem>(
     f: (a: InElem0) => InElem
   ): <Env, InErr, InDone, OutErr, OutElem, OutDone>(
@@ -600,7 +600,7 @@ export const contramapIn: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (a: InElem0) => InElem
   ): Channel<Env, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-} = channel.contramapIn
+} = channel.mapInputIn
 
 /**
  * Returns a new channel which is the same as this one but applies the given
@@ -609,7 +609,7 @@ export const contramapIn: {
  * @since 1.0.0
  * @category utils
  */
-export const contramapInEffect: {
+export const mapInputInEffect: {
   <Env1, InErr, InElem0, InElem>(
     f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>
   ): <Env, InDone, OutErr, OutElem, OutDone>(
@@ -619,7 +619,7 @@ export const contramapInEffect: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>
   ): Channel<Env | Env1, InErr, InElem0, InDone, OutErr, OutElem, OutDone>
-} = channel.contramapInEffect
+} = channel.mapInputInEffect
 
 /**
  * Returns a new channel, which is the same as this one, except that all the
@@ -1739,7 +1739,7 @@ export const provideLayer: {
  * @since 1.0.0
  * @category context
  */
-export const contramapContext: {
+export const mapInputContext: {
   <Env0, Env>(
     f: (env: Context.Context<Env0>) => Context.Context<Env>
   ): <InErr, InElem, InDone, OutErr, OutElem, OutDone>(
@@ -1749,7 +1749,7 @@ export const contramapContext: {
     self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     f: (env: Context.Context<Env0>) => Context.Context<Env>
   ): Channel<Env0, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-} = channel.contramapContext
+} = channel.mapInputContext
 
 /**
  * Splits the context into two parts, providing one part using the

--- a/src/Sink.ts
+++ b/src/Sink.ts
@@ -266,7 +266,7 @@ export const collectLeftover: <R, E, In, L, Z>(
  * @since 1.0.0
  * @category mapping
  */
-export const contramap = internal.contramap
+export const mapInput = internal.mapInput
 
 /**
  * Effectfully transforms this sink's input elements.
@@ -274,7 +274,7 @@ export const contramap = internal.contramap
  * @since 1.0.0
  * @category mapping
  */
-export const contramapEffect = internal.contramapEffect
+export const mapInputEffect = internal.mapInputEffect
 
 /**
  * Transforms this sink's input chunks. `f` must preserve chunking-invariance.
@@ -282,7 +282,7 @@ export const contramapEffect = internal.contramapEffect
  * @since 1.0.0
  * @category mapping
  */
-export const contramapChunks: {
+export const mapInputChunks: {
   <In0, In>(
     f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>
   ): <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R, E, In0, L, Z>
@@ -290,7 +290,7 @@ export const contramapChunks: {
     self: Sink<R, E, In, L, Z>,
     f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>
   ): Sink<R, E, In0, L, Z>
-} = internal.contramapChunks
+} = internal.mapInputChunks
 
 /**
  * Effectfully transforms this sink's input chunks. `f` must preserve
@@ -299,7 +299,7 @@ export const contramapChunks: {
  * @since 1.0.0
  * @category mapping
  */
-export const contramapChunksEffect: {
+export const mapInputChunksEffect: {
   <In0, R2, E2, In>(
     f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>
   ): <R, E, L, Z>(self: Sink<R, E, In, L, Z>) => Sink<R2 | R, E2 | E, In0, L, Z>
@@ -307,7 +307,7 @@ export const contramapChunksEffect: {
     self: Sink<R, E, In, L, Z>,
     f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>
   ): Sink<R | R2, E | E2, In0, L, Z>
-} = internal.contramapChunksEffect
+} = internal.mapInputChunksEffect
 
 /**
  * A sink that counts the number of elements fed to it.

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -2613,10 +2613,10 @@ export const provideServiceStream: {
  * @since 1.0.0
  * @category context
  */
-export const contramapContext: {
+export const mapInputContext: {
   <R0, R>(f: (env: Context.Context<R0>) => Context.Context<R>): <E, A>(self: Stream<R, E, A>) => Stream<R0, E, A>
   <E, A, R0, R>(self: Stream<R, E, A>, f: (env: Context.Context<R0>) => Context.Context<R>): Stream<R0, E, A>
-} = internal.contramapContext
+} = internal.mapInputContext
 
 /**
  * Splits the context into two parts, providing one part using the

--- a/src/internal/channel.ts
+++ b/src/internal/channel.ts
@@ -261,7 +261,7 @@ export const concatOut = <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
 ): Channel.Channel<Env, InErr, InElem, InDone, OutErr, OutElem, unknown> => core.concatAll(self)
 
 /** @internal */
-export const contramap = dual<
+export const mapInput = dual<
   <InDone0, InDone>(
     f: (a: InDone0) => InDone
   ) => <Env, InErr, InElem, OutErr, OutElem, OutDone>(
@@ -284,7 +284,7 @@ export const contramap = dual<
 })
 
 /** @internal */
-export const contramapEffect = dual<
+export const mapInputEffect = dual<
   <Env1, InErr, InDone0, InDone>(
     f: (i: InDone0) => Effect.Effect<Env1, InErr, InDone>
   ) => <Env, InElem, OutErr, OutElem, OutDone>(
@@ -307,7 +307,7 @@ export const contramapEffect = dual<
 })
 
 /** @internal */
-export const contramapError = dual<
+export const mapInputError = dual<
   <InErr0, InErr>(
     f: (a: InErr0) => InErr
   ) => <Env, InElem, InDone, OutErr, OutElem, OutDone>(
@@ -330,7 +330,7 @@ export const contramapError = dual<
 })
 
 /** @internal */
-export const contramapErrorEffect = dual<
+export const mapInputErrorEffect = dual<
   <Env1, InErr0, InErr, InDone>(
     f: (error: InErr0) => Effect.Effect<Env1, InErr, InDone>
   ) => <Env, InElem, OutErr, OutElem, OutDone>(
@@ -353,7 +353,7 @@ export const contramapErrorEffect = dual<
 })
 
 /** @internal */
-export const contramapIn = dual<
+export const mapInputIn = dual<
   <InElem0, InElem>(
     f: (a: InElem0) => InElem
   ) => <Env, InErr, InDone, OutErr, OutElem, OutDone>(
@@ -375,7 +375,7 @@ export const contramapIn = dual<
   return core.pipeTo(reader, self)
 })
 
-export const contramapInEffect = dual<
+export const mapInputInEffect = dual<
   <Env1, InErr, InElem0, InElem>(
     f: (a: InElem0) => Effect.Effect<Env1, InErr, InElem>
   ) => <Env, InDone, OutErr, OutElem, OutDone>(
@@ -2060,7 +2060,7 @@ export const provideLayer = dual<
   unwrapScoped(Effect.map(Layer.build(layer), (env) => core.provideContext(self, env))))
 
 /** @internal */
-export const contramapContext = dual<
+export const mapInputContext = dual<
   <Env0, Env>(
     f: (env: Context.Context<Env0>) => Context.Context<Env>
   ) => <InErr, InElem, InDone, OutErr, OutElem, OutDone>(
@@ -2293,7 +2293,7 @@ export const updateService = dual<
   tag: T,
   f: (resource: Context.Tag.Service<T>) => Context.Tag.Service<T>
 ): Channel.Channel<R | T, InErr, unknown, InDone, OutErr, OutElem, OutDone> =>
-  contramapContext(self, (context: Context.Context<R>) =>
+  mapInputContext(self, (context: Context.Context<R>) =>
     Context.merge(
       context,
       Context.make(tag, f(Context.unsafeGet(context, tag)))

--- a/src/internal/sink.ts
+++ b/src/internal/sink.ts
@@ -349,17 +349,17 @@ export const collectLeftover = <R, E, In, L, Z>(
   new SinkImpl(pipe(core.collectElements(toChannel(self)), channel.map(([chunks, z]) => [z, Chunk.flatten(chunks)])))
 
 /** @internal */
-export const contramap = dual<
+export const mapInput = dual<
   <In0, In>(f: (input: In0) => In) => <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>) => Sink.Sink<R, E, In0, L, Z>,
   <R, E, L, Z, In0, In>(self: Sink.Sink<R, E, In, L, Z>, f: (input: In0) => In) => Sink.Sink<R, E, In0, L, Z>
 >(
   2,
   <R, E, L, Z, In0, In>(self: Sink.Sink<R, E, In, L, Z>, f: (input: In0) => In): Sink.Sink<R, E, In0, L, Z> =>
-    pipe(self, contramapChunks(Chunk.map(f)))
+    pipe(self, mapInputChunks(Chunk.map(f)))
 )
 
 /** @internal */
-export const contramapEffect = dual<
+export const mapInputEffect = dual<
   <In0, R2, E2, In>(
     f: (input: In0) => Effect.Effect<R2, E2, In>
   ) => <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>) => Sink.Sink<R2 | R, E2 | E, In0, L, Z>,
@@ -373,7 +373,7 @@ export const contramapEffect = dual<
     self: Sink.Sink<R, E, In, L, Z>,
     f: (input: In0) => Effect.Effect<R2, E2, In>
   ): Sink.Sink<R | R2, E | E2, In0, L, Z> =>
-    contramapChunksEffect(
+    mapInputChunksEffect(
       self,
       (chunk) =>
         Effect.map(
@@ -384,7 +384,7 @@ export const contramapEffect = dual<
 )
 
 /** @internal */
-export const contramapChunks = dual<
+export const mapInputChunks = dual<
   <In0, In>(
     f: (chunk: Chunk.Chunk<In0>) => Chunk.Chunk<In>
   ) => <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>) => Sink.Sink<R, E, In0, L, Z>,
@@ -408,7 +408,7 @@ export const contramapChunks = dual<
 )
 
 /** @internal */
-export const contramapChunksEffect = dual<
+export const mapInputChunksEffect = dual<
   <In0, R2, E2, In>(
     f: (chunk: Chunk.Chunk<In0>) => Effect.Effect<R2, E2, Chunk.Chunk<In>>
   ) => <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>) => Sink.Sink<R2 | R, E2 | E, In0, L, Z>,
@@ -466,7 +466,7 @@ export const dimap = dual<
       readonly onInput: (input: In0) => In
       readonly onDone: (z: Z) => Z2
     }
-  ): Sink.Sink<R, E, In0, L, Z2> => map(contramap(self, options.onInput), options.onDone)
+  ): Sink.Sink<R, E, In0, L, Z2> => map(mapInput(self, options.onInput), options.onDone)
 )
 
 /** @internal */
@@ -494,7 +494,7 @@ export const dimapEffect = dual<
     }
   ): Sink.Sink<R | R2 | R3, E | E2 | E3, In0, L, Z2> =>
     mapEffect(
-      contramapEffect(self, options.onInput),
+      mapInputEffect(self, options.onInput),
       options.onDone
     )
 )
@@ -524,7 +524,7 @@ export const dimapChunks = dual<
     }
   ): Sink.Sink<R, E, In0, L, Z2> =>
     map(
-      contramapChunks(self, options.onInput),
+      mapInputChunks(self, options.onInput),
       options.onDone
     )
 )
@@ -553,7 +553,7 @@ export const dimapChunksEffect = dual<
       readonly onDone: (z: Z) => Effect.Effect<R3, E3, Z2>
     }
   ): Sink.Sink<R | R2 | R3, E | E2 | E3, In0, L, Z2> =>
-    mapEffect(contramapChunksEffect(self, options.onInput), options.onDone)
+    mapEffect(mapInputChunksEffect(self, options.onInput), options.onDone)
 )
 
 /** @internal */
@@ -750,7 +750,7 @@ export const filterInput: {
   <In, In1 extends In>(f: Predicate<In1>): <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>) => Sink.Sink<R, E, In1, L, Z>
 } = <In, In1 extends In>(f: Predicate<In1>) => {
   return <R, E, L, Z>(self: Sink.Sink<R, E, In, L, Z>): Sink.Sink<R, E, In1, L, Z> =>
-    pipe(self, contramapChunks(Chunk.filter(f)))
+    pipe(self, mapInputChunks(Chunk.filter(f)))
 }
 
 /** @internal */
@@ -768,7 +768,7 @@ export const filterInputEffect = dual<
     self: Sink.Sink<R, E, In, L, Z>,
     f: (input: In1) => Effect.Effect<R2, E2, boolean>
   ): Sink.Sink<R | R2, E | E2, In1, L, Z> =>
-    contramapChunksEffect(
+    mapInputChunksEffect(
       self,
       (chunk) => Effect.map(Effect.filter(chunk, f), Chunk.unsafeFromArray)
     )

--- a/src/internal/stream.ts
+++ b/src/internal/stream.ts
@@ -4603,7 +4603,7 @@ export const provideServiceStream = dual<
 )
 
 /** @internal */
-export const contramapContext = dual<
+export const mapInputContext = dual<
   <R0, R>(
     f: (env: Context.Context<R0>) => Context.Context<R>
   ) => <E, A>(self: Stream.Stream<R, E, A>) => Stream.Stream<R0, E, A>,
@@ -6772,7 +6772,7 @@ export const updateService = dual<
   ): Stream.Stream<R | T, E, A> =>
     pipe(
       self,
-      contramapContext((context) =>
+      mapInputContext((context) =>
         pipe(
           context,
           Context.add(tag, f(pipe(context, Context.unsafeGet(tag))))

--- a/test/Sink/error-handling.ts
+++ b/test/Sink/error-handling.ts
@@ -18,7 +18,7 @@ describe.concurrent("Sink", () => {
         Stream.run(
           pipe(
             Sink.drain,
-            Sink.contramapEffect((input: number) => Effect.try(() => input)),
+            Sink.mapInputEffect((input: number) => Effect.try(() => input)),
             Sink.mapError(() => ErrorSink)
           )
         ),

--- a/test/Sink/mapping.ts
+++ b/test/Sink/mapping.ts
@@ -18,71 +18,71 @@ describe.concurrent("Sink", () => {
       assert.strictEqual(result, "as")
     }))
 
-  it.effect("contramap - happy path", () =>
+  it.effect("mapInput - happy path", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramap((input: string) => Number.parseInt(input))
+        Sink.mapInput((input: string) => Number.parseInt(input))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
-  it.effect("contramap - error", () =>
+  it.effect("mapInput - error", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.fail("Ouch"),
-        Sink.contramap((input: string) => Number.parseInt(input))
+        Sink.mapInput((input: string) => Number.parseInt(input))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
-  it.effect("contramapChunks - happy path", () =>
+  it.effect("mapInputChunks - happy path", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramapChunks<string, number>(Chunk.map((_) => Number.parseInt(_)))
+        Sink.mapInputChunks<string, number>(Chunk.map((_) => Number.parseInt(_)))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
-  it.effect("contramapChunks - error", () =>
+  it.effect("mapInputChunks - error", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.fail("Ouch"),
-        Sink.contramapChunks<string, number>(Chunk.map(Number.parseInt))
+        Sink.mapInputChunks<string, number>(Chunk.map(Number.parseInt))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
-  it.effect("contramapEffect - happy path", () =>
+  it.effect("mapInputEffect - happy path", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramapEffect((s: string) => Effect.try(() => Number.parseInt(s)))
+        Sink.mapInputEffect((s: string) => Effect.try(() => Number.parseInt(s)))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink))
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
-  it.effect("contramapEffect - error", () =>
+  it.effect("mapInputEffect - error", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.fail("Ouch"),
-        Sink.contramapEffect((s: string) => Effect.try(() => Number.parseInt(s)))
+        Sink.mapInputEffect((s: string) => Effect.try(() => Number.parseInt(s)))
       )
       const result = yield* $(Stream.make("1", "2", "3"), Stream.run(sink), Effect.either)
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
-  it.effect("contramapEffect - error in transformation", () =>
+  it.effect("mapInputEffect - error in transformation", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramapEffect((s: string) =>
+        Sink.mapInputEffect((s: string) =>
           Effect.try(() => {
             const result = Number.parseInt(s)
             if (Number.isNaN(result)) {
@@ -96,11 +96,11 @@ describe.concurrent("Sink", () => {
       assert.deepStrictEqual(result, Either.left(Cause.RuntimeException("Cannot parse \"a\" to an integer")))
     }))
 
-  it.effect("contramapChunksEffect - happy path", () =>
+  it.effect("mapInputChunksEffect - happy path", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramapChunksEffect((chunk: Chunk.Chunk<string>) =>
+        Sink.mapInputChunksEffect((chunk: Chunk.Chunk<string>) =>
           pipe(
             chunk,
             Effect.forEach((s) => Effect.try(() => Number.parseInt(s))),
@@ -112,11 +112,11 @@ describe.concurrent("Sink", () => {
       assert.deepStrictEqual(Array.from(result), [1, 2, 3])
     }))
 
-  it.effect("contramapChunksEffect - error", () =>
+  it.effect("mapInputChunksEffect - error", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.fail("Ouch"),
-        Sink.contramapChunksEffect((chunk: Chunk.Chunk<string>) =>
+        Sink.mapInputChunksEffect((chunk: Chunk.Chunk<string>) =>
           pipe(
             chunk,
             Effect.forEach((s) => Effect.try(() => Number.parseInt(s))),
@@ -128,11 +128,11 @@ describe.concurrent("Sink", () => {
       assert.deepStrictEqual(result, Either.left("Ouch"))
     }))
 
-  it.effect("contramapChunksEffect - error in transformation", () =>
+  it.effect("mapInputChunksEffect - error in transformation", () =>
     Effect.gen(function*($) {
       const sink = pipe(
         Sink.collectAll<number>(),
-        Sink.contramapChunksEffect((chunk: Chunk.Chunk<string>) =>
+        Sink.mapInputChunksEffect((chunk: Chunk.Chunk<string>) =>
           pipe(
             chunk,
             Effect.forEach((s) =>


### PR DESCRIPTION
- Channel
  - contramap
  - contramapEffect
  - contramapError
  - contramapErrorEffect
  - contramapIn
  - contramapInEffect
  - contramapContext
- Sink
  - contramap
  - contramapEffect
  - contramapChunks
  - contramapChunksEffect
- Stream
  - contramapContext